### PR TITLE
add "key" argument to `Config.load`

### DIFF
--- a/olmo/config.py
+++ b/olmo/config.py
@@ -93,12 +93,15 @@ class BaseConfig:
             raise OlmoConfigurationError(str(e))
 
     @classmethod
-    def load(cls: Type[C], path: PathOrStr, overrides: Optional[List[str]] = None) -> C:
+    def load(cls: Type[C], path: PathOrStr, overrides: Optional[List[str]] = None, key: Optional[str] = None) -> C:
         """Load from a YAML file."""
         cls._register_resolvers()
         schema = om.structured(cls)
         try:
-            conf = om.merge(schema, om.load(str(path)))
+            raw = om.load(str(path))
+            if key is not None:
+                raw = raw[key]  # type: ignore
+            conf = om.merge(schema, raw)
             if overrides:
                 conf = om.merge(conf, om.from_dotlist(overrides))
             return cast(C, om.to_object(conf))


### PR DESCRIPTION
This should make it easier to load a `ModelConfig`, for example, from a training config YAML.

```python
from olmo.config import ModelConfig

model_config = ModelConfig.load("configs/300m-c4.yaml", key="model")
```
