### PR TITLE
Adjust LionW implementation

### DIFF
--- a/configs/c4-extra-tiny-debug.yaml
+++ b/configs/c4-extra-tiny-debug.yaml
@@ -23,9 +23,9 @@ model:
   init_std: 0.02
 
 optimizer:
-  name: decoupled_lionw
+  name: lionw
   learning_rate: 3.0e-4
-  weight_decay: 1.2e-4
+  weight_decay: 0.01
   betas:
   - 0.9
   - 0.95

--- a/configs/c4-large.yaml
+++ b/configs/c4-large.yaml
@@ -34,9 +34,9 @@ compile: null  # currently this doesn't work with activation checkpointing
 activation_checkpointing: true
 
 optimizer:
-  name: decoupled_lionw
+  name: lionw
   learning_rate: 8.0e-5
-  weight_decay: 4.0e-5
+  weight_decay: 0.01
   betas:
   - 0.9
   - 0.95

--- a/configs/c4-medium.yaml
+++ b/configs/c4-medium.yaml
@@ -31,9 +31,9 @@ compile:
   mode: default
 
 optimizer:
-  name: decoupled_lionw
+  name: lionw
   learning_rate: 1.2e-4
-  weight_decay: 0.6e-4
+  weight_decay: 0.01
   betas:
   - 0.9
   - 0.95

--- a/configs/c4-small.yaml
+++ b/configs/c4-small.yaml
@@ -32,9 +32,9 @@ compile:
   mode: default
 
 optimizer:
-  name: decoupled_lionw
+  name: lionw
   learning_rate: 2.0e-4
-  weight_decay: 1.0e-4
+  weight_decay: 0.01
   betas:
   - 0.9
   - 0.95

--- a/configs/c4-tiny.yaml
+++ b/configs/c4-tiny.yaml
@@ -34,9 +34,9 @@ compile:
   mode: default
 
 optimizer:
-  name: decoupled_lionw
+  name: lionw
   learning_rate: 3.0e-4
-  weight_decay: 1.5e-4
+  weight_decay: 0.01
   betas:
   - 0.9
   - 0.95

--- a/olmo/config.py
+++ b/olmo/config.py
@@ -317,14 +317,12 @@ class ModelConfig(BaseConfig):
 
 
 class OptimizerType(StrEnum):
-    adamw = "adamw"
-    decoupled_adamw = "decoupled_adamw"
-    decoupled_lionw = "decoupled_lionw"
+    lionw = "lionw"
 
 
 @dataclass
 class OptimizerConfig(BaseConfig):
-    name: OptimizerType = OptimizerType.decoupled_lionw
+    name: OptimizerType = OptimizerType.lionw
     learning_rate: float = 1.0e-4
     weight_decay: float = 0.0
     betas: Tuple[float, float] = (0.9, 0.95)

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -44,7 +44,7 @@ from olmo.config import (
 from olmo.data import DataCollator, MemMapDataset
 from olmo.exceptions import OlmoCliError, OlmoConfigurationError
 from olmo.model import Olmo
-from olmo.optim import DecoupledLionW
+from olmo.optim import LionW
 from olmo.util import (
     clean_opt,
     global_rank,
@@ -885,8 +885,8 @@ def build_dataloader(
 
 
 def build_optimizer(cfg: TrainConfig, model: nn.Module) -> torch.optim.Optimizer:
-    if cfg.optimizer.name == OptimizerType.decoupled_lionw:
-        return DecoupledLionW(
+    if cfg.optimizer.name == OptimizerType.lionw:
+        return LionW(
             model.parameters(),
             lr=cfg.optimizer.learning_rate,
             betas=cfg.optimizer.betas,


### PR DESCRIPTION
Weight decay is `lr x wd` instead of `lr x wd / initial_lr`. Also increases `wd` to suggested value from the Lion paper of 0.01. I didn't touch the LR but sounds like we should adjust that as well.