### PR TITLE
Only delete the shm file for our own GPU

### DIFF
--- a/scripts/run_with_environment.sh
+++ b/scripts/run_with_environment.sh
@@ -17,6 +17,6 @@ export LOCAL_WORLD_SIZE=$SLURM_NTASKS_PER_NODE
 export LOCAL_RANK=$SLURM_LOCALID
 export NODE_RANK=$((($RANK - $LOCAL_RANK) / $LOCAL_WORLD_SIZE))
 
-rm -f /dev/shm/rocm_smi*
+rm -f /dev/shm/rocm_smi_card$LOCAL_RANK
 
 exec $*


### PR DESCRIPTION
I have a suspicion that we're crashing processes when we delete their shm files from under them. I bet there is a race condition in RCCL code that goes
```
if shm file doesn't exist:
    create_shm_file()

# do some other stuff
# do more other stuff
# do so much other stuff that another process has time to delete the file

open_shm_file_or_segfault()
```