### PR TITLE
Add torch.no_grad() for vastly less memory usage

### DIFF
--- a/olmo/model.py
+++ b/olmo/model.py
@@ -825,8 +825,7 @@ class Olmo(nn.Module):
             tokens_generated += 1
 
             # Run forward pass of model to get logits, then normalize to get log probs.
-            with torch.no_grad():
-                output = self(input_ids, attention_mask=attention_mask, attention_bias=attention_bias)
+            output = self(input_ids, attention_mask=attention_mask, attention_bias=attention_bias)
             log_probs = F.log_softmax(output.logits[:, -1, :], dim=-1)
 
             # Create new state.
@@ -844,7 +843,8 @@ class Olmo(nn.Module):
             state["attention_mask"] = attention_mask
         if attention_bias is not None:
             state["attention_bias"] = attention_bias
-        token_ids, scores = beam_search.search(initial_preds, state, step)
+        with torch.no_grad():
+            token_ids, scores = beam_search.search(initial_preds, state, step)
 
         return OlmoGenerateOutput(
             token_ids=token_ids,  # type: ignore[arg-type]


### PR DESCRIPTION
Without this setting, the generate method uses a bizarre amount of memory, even with beam size 1 (e.g., the small model uses 4GB to load, goes up to 24GB generating 100 steps and OOM on a 48GB GPU for 200 steps). That leads me to think there might be some inefficiency somewhere else, but at least this setting helps a lot with memory usage.