### PR TITLE
Error handling

### DIFF
--- a/pretrain_data/filters/src/ai2_llm_filters/core_tools/data_types.py
+++ b/pretrain_data/filters/src/ai2_llm_filters/core_tools/data_types.py
@@ -11,11 +11,21 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 from msgspec import Struct
 
 
-class Ai2LlmFilterError(Exception):
+class Ai2LlmFatalError(Exception):
+    """Fatal error. Abort the entire process"""
+
+    pass
+
+
+class Ai2LlmShardError(Exception):
+    """Fail the shard and continue"""
+
     pass
 
 
 class Ai2LlmRetryableFailure(Exception):
+    """Retry if a shard throws this error"""
+
     pass
 
 


### PR DESCRIPTION
Modifications to error handling in `ai2_llm_filters`.

Current behavior:
 - With `--skip-on-failure`, ignore exceptions when processing individual lines in an input file
 - Without, abort the entire process on any exception

New behavior:
 - With `--retry-on-read-error`, retry the shard on intermittent failures
 - With `--skip-on-failure`, abort the processing of a single shard on any non-retryable exception
 - Without `--skip-on-failure`, abort the entire process on any exception

The most common retryable error is `IncompleteReadError`. 

The most common non-retryable error is `TextZLibDecompressorIO`, but I would rather drop the shard than continue processing with empty attributes, which would probably lead to contamination. I've been manually repairing files that fail with this error, so we can re-process those shards.