### PR TITLE
Use numpy for shuffling instead of torch

### DIFF
--- a/olmo/data/iterable_dataset.py
+++ b/olmo/data/iterable_dataset.py
@@ -69,9 +69,11 @@ class IterableDataset(torch.utils.data.IterableDataset[Dict[str, Any]]):
     def _build_global_indices(self) -> List[int]:
         if self.shuffle:
             # Deterministically shuffle based on epoch and seed
-            g = torch.Generator()
-            g.manual_seed(self.seed)
-            indices = torch.randperm(len(self.dataset), generator=g).tolist()  # type: ignore[arg-type]
+            # Torch built-in randomness is not very random, so we use numpy.
+            rng = np.random.Generator(np.random.PCG64(seed=self.seed))
+            indices = np.arange(len(self.dataset))
+            rng.shuffle(indices)
+            indices = list(indices)
         else:
             indices = list(range(len(self.dataset)))  # type: ignore[arg-type]
 


### PR DESCRIPTION
Randomness with torch:
![image](https://github.com/allenai/LLM/assets/920638/7b15a787-b52f-4c42-a815-982eaf127ab5)

Randomness with numpy:
![image](https://github.com/allenai/LLM/assets/920638/2d8dbd8e-a028-45f9-a130-2dd061aa93e9)
