### PR TITLE
Adding a torch barrier before loading of pre-train checkpoint

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -178,9 +178,9 @@ def main(cfg: TrainConfig) -> None:
             log.info("Saving pre-train checkpoint...")
             checkpoint_path = trainer.save_checkpoint(checkpoint_type=checkpoint_type)
             log.info(f"Checkpoint saved to {checkpoint_path}")
-            
+
             barrier()
-            
+
             # And they we verify that we can load it.
             log.info("Attempting to load pre-train checkpoint...")
             trainer.restore_checkpoint(checkpoint_path, checkpoint_type=checkpoint_type)


### PR DESCRIPTION
I've noticed occasionally when running on the Cirrascale A100 cluster that the initial checkpoint is sometimes read before all nodes are finished writing (leading to a FileNotFoundError).

Here's [an example](https://beaker.org/api/v3/jobs/01H5QKG7HF9AT841EYA3FBZ40P/logs?tail=2).

A barrier here should prevent this race condition. 
