### PR TITLE
Inital GQ Attn Impl, issue w scaled_dot_product_attn

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -46,7 +46,7 @@ def model_config() -> ModelConfig:
         eos_token_id=50256,
         pad_token_id=50256,
         d_model=128,
-        n_heads=2,
+        n_heads=4,
         n_layers=3,
         max_sequence_length=512,
     )


### PR DESCRIPTION
I tried implementing [grouped query attention](https://arxiv.org/pdf/2305.13245.pdf) in this PR, but seems that Pytorch's `scaled_dot_product_attention` doesn't support the kind of broadcasting we'd need for this. Revisit if/when this gets fixed on Pytorch's end. 