### PR TITLE
Fix speed issue on LUMI with 7B model

### DIFF
--- a/olmo/config.py
+++ b/olmo/config.py
@@ -501,6 +501,18 @@ class CompilerConfig(BaseConfig):
     """
 
 
+class FSDPWrapStrategy(StrEnum):
+    by_block = "by_block"
+    """
+    Wrap each OLMo block with its own FSDP instance.
+    """
+
+    size_based = "size_based"
+    """
+    Used PyTorch's default size-based auto wrap policy.
+    """
+
+
 @dataclass
 class FSDPConfig(BaseConfig):
     use_orig_params: bool = True
@@ -510,10 +522,10 @@ class FSDPConfig(BaseConfig):
 
     sharding_strategy: ShardingStrategy = ShardingStrategy.FULL_SHARD
 
-    nested_wrapping: bool = False
+    wrapping_strategy: Optional[FSDPWrapStrategy] = None
     """
-    If True, the model is wrapped with a nested strategy according to the model's `fsdp_wrap_fn`.
-    If False (the default), the model is wrapped as a single top-level FSDP instance.
+    The wrapping strategy to use. If ``None``, the default, the model is wrapped with a single top-level
+    FSDP instance.
     """
 
 

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -13,9 +13,10 @@ import torch.distributed as dist
 import wandb
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from torch.distributed.fsdp import MixedPrecision
+from torch.distributed.fsdp.wrap import size_based_auto_wrap_policy
 from torchmetrics import MeanMetric
 
-from olmo.config import CheckpointType, TrainConfig
+from olmo.config import CheckpointType, FSDPWrapStrategy, TrainConfig
 from olmo.data import build_train_dataloader
 from olmo.eval import build_evaluators
 from olmo.exceptions import OlmoCliError, OlmoConfigurationError
@@ -107,6 +108,11 @@ def main(cfg: TrainConfig) -> None:
 
     # Wrap the model in FSDP.
     log.info("Wrapping model with FDSP...")
+    wrap_policy = None
+    if cfg.fsdp.wrapping_strategy == FSDPWrapStrategy.by_block:
+        wrap_policy = olmo_model.fsdp_wrap_fn
+    elif cfg.fsdp.wrapping_strategy == FSDPWrapStrategy.size_based:
+        wrap_policy = size_based_auto_wrap_policy
     fsdp_model = FSDP(
         olmo_model,
         sharding_strategy=cfg.fsdp.sharding_strategy,
@@ -115,7 +121,7 @@ def main(cfg: TrainConfig) -> None:
             reduce_dtype=cfg.autocast_precision,
             buffer_dtype=cfg.autocast_precision,
         ),
-        auto_wrap_policy=olmo_model.fsdp_wrap_fn if cfg.fsdp.nested_wrapping else None,
+        auto_wrap_policy=wrap_policy,
         use_orig_params=cfg.fsdp.use_orig_params,  # needed for compile and some of our optimizer/parameter metrics
         limit_all_gathers=True,
         device_id=get_local_rank(),


### PR DESCRIPTION
Our FSDP wrapping policy (`Olmo.fsdp_wrap_fn`) used to have a bug which accidentally made training faster. See:

https://github.com/allenai/LLM/compare/152a3595f4a523a8044f23eada7da068b301158d..main#diff-ef8ab7279deeec716e70a1cc9ab2accaaa60f27b301cc0733f1e00a9e39c07d1R905-R907

The result of the bug was that our model was wrapped in a single top-level FSDP instance, instead of the intended behavior of wrapping each block within their own FSDP instance.
Naturally it makes sense to wrap block-by-block, but as @dirkgr found out this actually slows training down substantially on LUMI with the 7B model on more than 32 nodes.

So I've added a new configuration option `fsdp.wrapping_strategy` that defaults to `None`, which gives us back the original (unintended) behavior. We'll have to tune this again when we scale up to 70B params.
