### PR TITLE
use (rsqrt * x) instead of (x / sqrt)

### DIFF
--- a/olmo/model.py
+++ b/olmo/model.py
@@ -174,7 +174,9 @@ class AMDLayerNorm(LayerNormBase):
         x = self._cast_if_autocast_enabled(x, dtype=torch.float32)
         with torch.autocast(enabled=False, device_type=x.device.type):
             var, mean = torch.var_mean(x, dim=-1, correction=0, keepdim=True)
-            x = (var + self.eps).rsqrt() * (x - mean)  # rsqrt should be more stable than 1/sqrt
+            var.add_(self.eps)
+            var.rsqrt_()  # rsqrt should be more stable than 1/sqrt
+            x = var * (x - mean)
             if self.weight is not None:
                 x.mul_(self.weight)
             if self.bias is not None:


### PR DESCRIPTION
According to this function in apex (which is what is being used in llama)
https://github.com/NVIDIA/apex/blob/741bdf50825a97664db08574981962d66436d16a/csrc/layer_norm_cuda_kernel.cu#L353, layernorm is computed as follows:

```
var, mean = var_and_mean(x)
invvar = rsqrt(var + epsilon)
norm_x = invvar * (x - mean)
```

This pr makes our layernorm match this, hoping to benefit from numerical stability tricks in `rsqrt`. 