### PR TITLE
fix for torch 2.1 inits

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -132,6 +132,7 @@ def main(cfg: TrainConfig) -> None:
         device_id=get_local_rank(),
         param_init_fn=param_init_fn,
     )
+    # when param_init_fn is None, FSDP will call reset_parameters() automatically
     if param_init_fn is not None:
         olmo_model.reset_parameters()
 


### PR DESCRIPTION
In torch 2.1 FSDP now only calls reset_parameters() on modules which directly manage parameters (i.e. not the top level Olmo module).

Very simple fix: call olmo_model.reset_parameters() after the FSDP wrap. this recovers the loss curve from torch 2.0.1 
No changes if using torch version < 2.1.0
