### PR TITLE
Fix leftover data partitioning logic

### DIFF
--- a/olmo/data/iterable_dataset.py
+++ b/olmo/data/iterable_dataset.py
@@ -136,9 +136,7 @@ class IterableDataset(torch.utils.data.IterableDataset[Dict[str, Any]]):
             # worker 1 the 2nd chunk of `device_train_batch_size` indices, etc...
             if self.device_batch_size is not None:
                 truncated_size = self.device_batch_size * (len(indices) // self.device_batch_size)
-                left_overs = indices[
-                    truncated_size + worker_info.id :: worker_info.num_workers
-                ]
+                left_overs = indices[truncated_size + worker_info.id :: worker_info.num_workers]
                 indices = (
                     indices[:truncated_size]
                     .reshape((-1, self.device_batch_size))[worker_info.id :: worker_info.num_workers]  # type: ignore


### PR DESCRIPTION
While debugging the num_workers > 0 issue, I noticed that the logic that partitions data items between workers does not divide the "leftovers" correctly. The current logic leads to a few items being shared between several workers (ideally there should be no overlap), and more items not being assigned to any worker. We will probably never reach the leftovers and so it's not a real issue, but better to fix than to leave unfixed.