### PR TITLE
Fix SDP NaN bug

### DIFF
--- a/olmo/model.py
+++ b/olmo/model.py
@@ -516,7 +516,7 @@ class OlmoBlock(nn.Module):
             q,
             k,
             v,
-            attn_mask=None if attention_bias is None else attention_bias.to(dtype=dtype),
+            attn_mask=attention_bias,
             dropout_p=0.0 if not self.training else self.config.attention_dropout,
             is_causal=attention_bias is None,
         )


### PR DESCRIPTION
Fixes #322. Note that this is **not** an issue with pre-training.

This bug only affects batched inference or training when padding is involved. Luckily this is not an issue with LM pre-training since there's no padding in the pre-training data.

The problem is that `F.scaled_dot_product_attention()` will return NaNs when some tokens are masked out with `float("-inf")` (due to padding). See [pytorch#103749](https://github.com/pytorch/pytorch/issues/103749) for example. Negative infs can also appear when AMP is enabled and the attention bias is float32 with `float32.min` instead of `float("-inf")` since when we cast the bias to bfloat16 (or float16) this will change `float32.min` into `float("-inf")`. So to avoid this we need to cast the attention bias to the target data type of `F.scaled_dot_product_attention()` _and then_ make sure there's no `float("-inf")` in it.

For example:

```python
import torch
import torch.nn.functional as F

from olmo.config import ModelConfig
from olmo.model import OlmoBlock, causal_attention_bias

device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
seq_len = 8
bsz = 2
cfg = ModelConfig(d_model=128, n_heads=4, max_sequence_length=seq_len)
attn_mask = torch.ones(bsz, seq_len, dtype=torch.float, device=device)
attn_mask[1][:-2] = 0.0  # mask out some elements for padding

attn_mask = (1.0 - attn_mask) * torch.finfo(attn_mask.dtype).min
attn_mask = attn_mask[:, None, None, :]

attn_bias = causal_attention_bias(seq_len, attn_mask.device)
attn_bias = attn_bias + attn_mask
attn_bias.masked_fill_(attn_bias == float("-inf"), torch.finfo(attn_bias.dtype).min)

input_shape = (2, cfg.n_heads, seq_len, cfg.d_model // cfg.n_heads)
q, k, v = (
    torch.rand(*input_shape, device=device),
    torch.rand(*input_shape, device=device),
    torch.rand(*input_shape, device=device),
)

with torch.no_grad():
    with torch.autocast(device.type, torch.bfloat16, enabled=True):
        # This will fail if don't call this casting method.
        # But currently this will always fail on CPU because `torch.is_autocast_enabled()`
        # always returns false on CPU. See https://github.com/pytorch/pytorch/issues/110966.
        attn_bias = OlmoBlock._cast_attn_bias(attn_bias, q.dtype)
        attn = F.scaled_dot_product_attention(q, k, v, attn_mask=attn_bias, is_causal=False)
    assert torch.isfinite(attn).all()
```

Note this fix still fails on CPU due to https://github.com/pytorch/pytorch/issues/110966.

An alternative is to avoid using `F.scaled_dot_product_attention()` because this is not an issue with manual implementations of SDP, or to run `F.scaled_dot_product_attention()` in full precision.
