### PR TITLE
Add mitch-ish 256 for LUMI

### DIFF
--- a/scripts/lumi/mitch-ish-7b.sh
+++ b/scripts/lumi/mitch-ish-7b.sh
@@ -14,7 +14,7 @@
 module load LUMI/22.08 partition/G
 
 # export OLMO_CONTAINER=llm-lumi_latest.sif
-export OLMO_CONTAINER=llm-lumi-torch32_latest.sif
+export OLMO_CONTAINER=llm-lumi-torch21_latest.sif
 
 export OMP_NUM_THREADS=$SLURM_CPUS_PER_TASK
 export MPICH_GPU_SUPPORT_ENABLED=1


### PR DESCRIPTION
This adds a 256-node mitch-ish run for LUMI (2x the batch size). I think this will run as-is, but if not we'll have to try a different FSDP wrapping strategy.