### PR TITLE
Add two more FSDP wrapping strategies

### DIFF
--- a/olmo/config.py
+++ b/olmo/config.py
@@ -540,10 +540,20 @@ class FSDPWrapStrategy(StrEnum):
     Wrap each OLMo block with its own FSDP instance.
     """
 
+    by_block_and_size = "by_block_and_size"
+    """
+    Like 'by_block' but `wte` and `ff_out` will be wrapped separately as well.
+    """
+
     by_block_group = "by_block_group"
     """
     Wrap each block group together into its own FSDP instance.
     This requires :attr:`~ModelConfig.block_group_size` to be bigger than 1.
+    """
+
+    by_block_group_and_size = "by_block_group_and_size"
+    """
+    Like 'by_block_group' but `wte` and `ff_out` will be wrapped separately as well.
     """
 
     size_based = "size_based"


### PR DESCRIPTION
Adds two more FSDP wrapping strategies:
- "by_block_and_size"
- "by_block_group_and_size"

These are extensions of the "by_block" and "by_block_group" strategies, respectively, where the embedding and final linear layer will also be wrapped separately.

(Note: with the mitch-ish config I've bound that "size_based" has the same result as "by_block_and_size")
