### PR TITLE
[Storage Cleaner] Migrate to cached_path

### DIFF
--- a/scripts/storage_cleaner.py
+++ b/scripts/storage_cleaner.py
@@ -630,7 +630,6 @@ def perform_operation(args: argparse.Namespace):
 
 
 def _add_cached_path_s3_client():
-
     class S3SchemeClient(S3Client):
         """
         A class that the `cached_path` module can use to retrieve resources from


### PR DESCRIPTION
The cloud file download and unarchiving functionality of `scripts/storage_cleaner.py` can be implemented with the `cached_path` module instead of manual implementations. I initially avoided this because `cached_path` does not natively support R2, but in the long run I have found that implementing R2 for `cached_path` is the lesser of the 2 poisons.

PR Train (in repair):
1. https://github.com/allenai/LLM/pull/364
2. **This PR** https://github.com/allenai/LLM/pull/378
3. https://github.com/allenai/LLM/pull/379
4. https://github.com/allenai/LLM/pull/390