### PR TITLE
[Storage Cleaner] Add option to get full paths when listing entries

### DIFF
--- a/scripts/storage_cleaner.py
+++ b/scripts/storage_cleaner.py
@@ -47,7 +47,7 @@ class StorageAdapter(ABC):
         Returns only top-level entries (i.e. not entries in subdirectories).
 
         `full_path`: If `full_path` is set to true, returned entries are valid full paths. These full paths
-        might not have `path` as their parent (for example, if `path` corresponds to an archive file).
+        might not have `path` as their parent and might not use the same type of storage as `path`.
         If `full_path` is set to false, returned entries are file/directory names.
 
         `max_file_size`: Sets a threshold (in bytes) for the largest size file to retain within entries.


### PR DESCRIPTION
This PR adds the option to get full file/directory paths when listing entries of an archive file or directory. For archive files, this may change the path from a cloud URL to a local file path. This PR has multiple benefits:

- Users of `list_entries` no longer need to worry about whether the path corresponds to an archive file or a directory when they are using the results. They just need to be mindful that the entries could be in a different storage system.
- Previously, there was a hacky way of dealing with runs having an extra nested dir. Now `_get_archive_run_entry_paths` clearly points out this issue and deals with both the presence and absence of the extra nested dir.

PR Train:
1. https://github.com/allenai/LLM/pull/364
2. https://github.com/allenai/LLM/pull/378
3. **This PR** https://github.com/allenai/LLM/pull/379
4. https://github.com/allenai/LLM/pull/380
5. https://github.com/allenai/LLM/pull/381
6. https://github.com/allenai/LLM/pull/382