### PR TITLE
initialize distributed group before logging

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -46,9 +46,9 @@ def main(cfg: TrainConfig) -> None:
             "setting has no effect."
         )
 
-    # Initialize process group and set device.
-    dist.init_process_group(backend="nccl")
     barrier()
+
+    # Set CUDA device.
     torch.cuda.set_device(f"cuda:{get_local_rank()}")
     device = torch.device("cuda")
 
@@ -239,6 +239,9 @@ def main(cfg: TrainConfig) -> None:
 
 
 if __name__ == "__main__":
+    # Initialize process group.
+    dist.init_process_group(backend="nccl")
+
     prepare_cli_environment()
 
     try:


### PR DESCRIPTION
Recent changes to our `torch_utils` messed up how we configure logging in a distributed-aware way. As a result every rank was logging on LUMI. To fix that we just need to initialize the distributed process group before configuring logging.
