### PR TITLE
[Storage Cleaner] Move unarchiving logic to cleaning jobs

### DIFF
--- a/scripts/storage_cleaner.py
+++ b/scripts/storage_cleaner.py
@@ -138,9 +138,7 @@ class LocalFileSystemAdapter(StorageAdapter):
             for entry in dir_obj.iterdir()
             if (
                 (include_files or not entry.is_file())
-                and (
-                    not entry.is_file() or max_file_size is None or self._get_file_size(entry) <= max_file_size
-                )
+                and (not entry.is_file() or max_file_size is None or self._get_file_size(entry) <= max_file_size)
             )
         ]
 


### PR DESCRIPTION
I originally designed the storage cleaner with the idea that `StorageAdapter`s would abstract out lots of the FS-related operations. I included handling archives in that abstraction, which turns out to have been a bad idea. This PR moves the responsibility of handling unarchiving from the `StorageAdapter` to the storage cleaning job that needs to use unarchiving. It should hopefully make the storage cleaner easier to work with (especially since none of the `full_path` stuff from https://github.com/allenai/LLM/pull/379 will be needed anymore).