### PR TITLE
[Storage cleaner] Improve handling of temp directories and files

### DIFF
--- a/scripts/storage_cleaner.py
+++ b/scripts/storage_cleaner.py
@@ -733,7 +733,7 @@ def delete_bad_runs(run_paths: List[str], config: DeleteBadRunsConfig):
         log.info("Starting to check if run %s should be deleted", run_path)
         _delete_if_bad_run(storage, run_path, config)
 
-        # Delete temp dir after each run to avoid memory bloat
+        # Delete temp dir after each run to avoid storage bloat
         if Path(config.temp_dir).is_dir():
             log.info("Deleting temp dir %s", config.temp_dir)
             shutil.rmtree(config.temp_dir)


### PR DESCRIPTION
The current implementation has a few issues with respect to temp directories and files. Below I list the issues and their corresponding fixes in this PR.

__Operations do not delete all the temp content (e.g. unarchived directories) added to the user-provided temp directory.__
Handle temporary directory creation and completion in `perform_operation`, which is shared by all operations.

__Bad run deletion can take several runs as input, so the number of uncleaned artifacts can easily grow.__
Added temp directory cleanup after each run.

__The unsharding temp directory is not under the user-provided temp directory.__
Changed unsharding temp directory creation to fix this.

The majority of the additions/deletions were caused from moving `perform_operation` down the file (https://github.com/allenai/OLMo/commit/77c648afd16c50002790ff00c03b0de8a7be11d0).