### PR TITLE
[Storage cleaner] Fix is_file error when cloud storage key is empty

### DIFF
--- a/scripts/storage_cleaner.py
+++ b/scripts/storage_cleaner.py
@@ -265,6 +265,9 @@ class GoogleCloudStorageAdapter(StorageAdapter):
         return blob.size
 
     def _is_file(self, bucket_name: str, key: str) -> bool:
+        if len(key) == 0:
+            return False
+
         bucket = self.gcs_client.bucket(bucket_name)
         blob = bucket.blob(key)
         try:
@@ -525,6 +528,9 @@ class S3StorageAdapter(StorageAdapter):
                 raise RuntimeError(f"The following keys failed to be deleted: {undeleted_keys}")
 
     def _is_file(self, bucket_name: str, key: str) -> bool:
+        if len(key) == 0:
+            return False
+
         try:
             self._s3_client.head_object(Bucket=bucket_name, Key=key)
             return True


### PR DESCRIPTION
`is_file` causes an error when cloud storage key is empty because the key is expected to be at least 1 char long. It should return false instead.