### PR TITLE
Don't init params when loading hf_olmo

### DIFF
--- a/hf_olmo/modeling_olmo.py
+++ b/hf_olmo/modeling_olmo.py
@@ -33,14 +33,14 @@ class OLMoForCausalLM(PreTrainedModel):
     base_model_prefix = "model"
     _no_split_modules = ["OLMoBlock"]
 
-    def __init__(self, config: OLMoConfig, model: Optional[Olmo] = None):
+    def __init__(self, config: OLMoConfig, model: Optional[Olmo] = None, init_params: bool = False):
         super().__init__(config)
 
         if not model:
             model_config = create_model_config_from_pretrained_config(config)
             # Initialize model (always on CPU to start with so we don't run out of GPU memory).
             model_config.init_device = "cpu"
-            self.model = Olmo(model_config, init_params=False)
+            self.model = Olmo(model_config, init_params=init_params)
         else:
             self.model = model
 

--- a/tests/hf_olmo/hf_olmo_test.py
+++ b/tests/hf_olmo/hf_olmo_test.py
@@ -193,7 +193,7 @@ def test_forward(
     hf_config = OLMoConfig(**model.config.asdict())
 
     seed_all(1234)
-    hf_model = OLMoForCausalLM(hf_config).eval()
+    hf_model = OLMoForCausalLM(hf_config, init_params=True).eval()
 
     input1 = tokenizer.encode("My name is OLMo!")
     input2 = tokenizer.encode("I'm a delightful large open language model :)")


### PR DESCRIPTION
I found that setting init_params to True led to an un-googleable error when trying to finetune hf olmo with deepspeed, stack trace below:
```
Traceback (most recent call last):
  File "/net/nfs.cirrascale/allennlp/hamishi/open-instruct/open_instruct/finetune.py", line 743, in <module>
    main()
  File "/net/nfs.cirrascale/allennlp/hamishi/open-instruct/open_instruct/finetune.py", line 448, in main
    model = AutoModelForCausalLM.from_pretrained(
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/hamishi/.conda/envs/open-instruct/lib/python3.11/site-packages/transformers/models/auto/auto_factory.py", line 561, in from_pretrained
    return model_class.from_pretrained(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/hamishi/.conda/envs/open-instruct/lib/python3.11/site-packages/transformers/modeling_utils.py", line 3236, in from_pretrained
    model = cls(config, *model_args, **model_kwargs)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/hamishi/.conda/envs/open-instruct/lib/python3.11/site-packages/deepspeed/runtime/zero/partition_parameters.py", line 443, in wrapper
    f(module, *args, **kwargs)
  File "/net/nfs.cirrascale/allennlp/hamishi/LLM/hf_olmo/modeling_olmo.py", line 43, in __init__
    self.model = Olmo(model_config, init_params=True)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/hamishi/.conda/envs/open-instruct/lib/python3.11/site-packages/deepspeed/runtime/zero/partition_parameters.py", line 443, in wrapper
    f(module, *args, **kwargs)
  File "/net/nfs.cirrascale/allennlp/hamishi/LLM/olmo/model.py", line 1041, in __init__
    self.reset_parameters()
  File "/net/nfs.cirrascale/allennlp/hamishi/LLM/olmo/model.py", line 1072, in reset_parameters
    init_weights(
  File "/net/nfs.cirrascale/allennlp/hamishi/LLM/olmo/initialization.py", line 50, in init_weights
    nn.init.trunc_normal_(module.weight, mean=0.0, std=std, a=-3 * std, b=3 * std)
  File "/home/hamishi/.conda/envs/open-instruct/lib/python3.11/site-packages/torch/nn/init.py", line 176, in trunc_normal_
    return _no_grad_trunc_normal_(tensor, mean, std, a, b)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/hamishi/.conda/envs/open-instruct/lib/python3.11/site-packages/torch/nn/init.py", line 46, in _no_grad_trunc_normal_
    tensor.erfinv_()
RuntimeError: "erfinv_cuda" not implemented for 'BFloat16'
```

Setting it to False appears to fix this. Unsure if there was a strong reason for setting this to true originally, it seems to behave fine during finetuning and loading models afterwards.