### PR TITLE
Fix HF integration for Python < 3.10

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -104,7 +104,7 @@ jobs:
   gpu_tests:
     name: GPU Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 8
     env:
       BEAKER_TOKEN: ${{ secrets.BEAKER_TOKEN }}
       BEAKER_IMAGE: olmo-torch2-test

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -10,6 +10,7 @@ on:
       - main
     paths:
       - 'olmo/**'
+      - 'hf_olmo/**'
 
 jobs:
   changelog:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Fixed an issue with the HuggingFace integration where we were inadvertently using a feature that was introduced in Python 3.10, causing an error for older Python versions.
+
 ## [v0.2.3](https://github.com/allenai/OLMo/releases/tag/v0.2.3) - 2024-01-31
 
 ## [v0.2.2](https://github.com/allenai/LLM/releases/tag/v0.2.2) - 2023-12-10

--- a/hf_olmo/modeling_olmo.py
+++ b/hf_olmo/modeling_olmo.py
@@ -1,3 +1,4 @@
+from dataclasses import fields
 from typing import List, Optional, Tuple, Union
 
 import torch
@@ -17,8 +18,8 @@ def create_model_config_from_pretrained_config(config: OLMoConfig):
     """
 
     kwargs = {}
-    for key in ModelConfig.__match_args__:
-        kwargs[key] = getattr(config, key)
+    for field in fields(ModelConfig):
+        kwargs[field.name] = getattr(config, field.name)
 
     model_config = ModelConfig(**kwargs)
     return model_config


### PR DESCRIPTION
We were inadvertently using a feature that was introduced in Python
3.10. Luckily there was a quick fix so we can continue to support Python
as far back as 3.8.

Closes #422.
