### PR TITLE
Work with Python 3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed default value of `--tokenizer` argument to `scripts/prepare_tulu_data.py` to be an absolute path, not relative path, the script can be run from other directories.
 - Added the option to directly pass input embeddings to `OLMo` and `OLMoForCausalLM`.
+- Added support for Python 3.8.
 
 ## [v0.2.4](https://github.com/allenai/OLMo/releases/tag/v0.2.4) - 2024-02-02
 

--- a/olmo/model.py
+++ b/olmo/model.py
@@ -6,6 +6,7 @@ Adapted from
 
 from __future__ import annotations
 
+import sys 
 import logging
 import math
 from abc import abstractmethod
@@ -29,13 +30,6 @@ import torch.backends.cuda
 import torch.nn as nn
 import torch.nn.functional as F
 from torch import einsum
-import sys 
-if sys.version_info.minor > 8 :
-    from collections.abc import MutableMapping
-elif sys.version_info.minor == 8:
-    from typing import MutableMapping
-else:
-    raise SystemExit("This script supports Python 3.8 or higher")
 
 from .aliases import PathOrStr
 from .beam_search import BeamSearch, Constraint, FinalSequenceScorer, Sampler
@@ -70,6 +64,12 @@ __all__ = [
     "OlmoGenerateOutput",
 ]
 
+if sys.version_info.minor > 8 :
+    from collections.abc import MutableMapping
+elif sys.version_info.minor == 8:
+    from typing import MutableMapping
+else:
+    raise SystemExit("This script supports Python 3.8 or higher")
 
 log = logging.getLogger(__name__)
 

--- a/olmo/model.py
+++ b/olmo/model.py
@@ -10,10 +10,6 @@ import logging
 import math
 from abc import abstractmethod
 from collections import defaultdict
-try:
-    from collections.abc import MutableMapping
-except ImportError:
-    from typing import MutableMapping
 from functools import partial
 from typing import (
     Callable,
@@ -33,6 +29,13 @@ import torch.backends.cuda
 import torch.nn as nn
 import torch.nn.functional as F
 from torch import einsum
+import sys 
+if sys.version_info.minor > 8 :
+    from collections.abc import MutableMapping
+elif sys.version_info.minor == 8:
+    from typing import MutableMapping
+else:
+    raise SystemExit("This script supports Python 3.8 or higher")
 
 from .aliases import PathOrStr
 from .beam_search import BeamSearch, Constraint, FinalSequenceScorer, Sampler

--- a/olmo/model.py
+++ b/olmo/model.py
@@ -46,6 +46,13 @@ from .exceptions import OlmoConfigurationError
 from .initialization import ModuleType, init_weights
 from .torch_util import ensure_finite_
 
+if sys.version_info.minor > 8 :
+    from collections.abc import MutableMapping
+elif sys.version_info.minor == 8:
+    from typing import MutableMapping
+else:
+    raise SystemExit("This script supports Python 3.8 or higher")
+
 __all__ = [
     "LayerNormBase",
     "LayerNorm",
@@ -64,12 +71,6 @@ __all__ = [
     "OlmoGenerateOutput",
 ]
 
-if sys.version_info.minor > 8 :
-    from collections.abc import MutableMapping
-elif sys.version_info.minor == 8:
-    from typing import MutableMapping
-else:
-    raise SystemExit("This script supports Python 3.8 or higher")
 
 log = logging.getLogger(__name__)
 

--- a/olmo/model.py
+++ b/olmo/model.py
@@ -6,9 +6,9 @@ Adapted from
 
 from __future__ import annotations
 
-import sys 
 import logging
 import math
+import sys
 from abc import abstractmethod
 from collections import defaultdict
 from functools import partial
@@ -46,7 +46,7 @@ from .exceptions import OlmoConfigurationError
 from .initialization import ModuleType, init_weights
 from .torch_util import ensure_finite_
 
-if sys.version_info.minor > 8 :
+if sys.version_info.minor > 8:
     from collections.abc import MutableMapping
 elif sys.version_info.minor == 8:
     from typing import MutableMapping

--- a/olmo/model.py
+++ b/olmo/model.py
@@ -10,10 +10,10 @@ import logging
 import math
 from abc import abstractmethod
 from collections import defaultdict
-from collections.abc import MutableMapping
 from functools import partial
 from typing import (
     Callable,
+    MutableMapping, 
     Dict,
     Iterable,
     List,

--- a/olmo/model.py
+++ b/olmo/model.py
@@ -10,10 +10,13 @@ import logging
 import math
 from abc import abstractmethod
 from collections import defaultdict
+try:
+    from collections.abc import MutableMapping
+except ImportError:
+    from typing import MutableMapping
 from functools import partial
 from typing import (
     Callable,
-    MutableMapping, 
     Dict,
     Iterable,
     List,

--- a/olmo/util.py
+++ b/olmo/util.py
@@ -23,7 +23,6 @@ from rich.progress import Progress
 from rich.text import Text
 from rich.traceback import Traceback
 
-
 from .aliases import PathOrStr
 from .exceptions import (
     OlmoCliError,

--- a/olmo/util.py
+++ b/olmo/util.py
@@ -7,7 +7,10 @@ import time
 import warnings
 from datetime import datetime
 from enum import Enum
-from functools import cache
+try:
+    from functools import cache 
+except ImportError:
+    from functools import lru_cache as cache
 from itertools import cycle, islice
 from pathlib import Path
 from queue import Queue

--- a/olmo/util.py
+++ b/olmo/util.py
@@ -34,10 +34,10 @@ from .exceptions import (
 from .torch_util import get_global_rank, get_local_rank, get_node_rank, is_distributed
 
 try:
-    from functools import cache 
+    from functools import cache
 except ImportError:
     from functools import lru_cache as cache
-    
+
 
 class StrEnum(str, Enum):
     """

--- a/olmo/util.py
+++ b/olmo/util.py
@@ -7,10 +7,6 @@ import time
 import warnings
 from datetime import datetime
 from enum import Enum
-try:
-    from functools import cache 
-except ImportError:
-    from functools import lru_cache as cache
 from itertools import cycle, islice
 from pathlib import Path
 from queue import Queue
@@ -27,6 +23,7 @@ from rich.progress import Progress
 from rich.text import Text
 from rich.traceback import Traceback
 
+
 from .aliases import PathOrStr
 from .exceptions import (
     OlmoCliError,
@@ -37,6 +34,11 @@ from .exceptions import (
 )
 from .torch_util import get_global_rank, get_local_rank, get_node_rank, is_distributed
 
+try:
+    from functools import cache 
+except ImportError:
+    from functools import lru_cache as cache
+    
 
 class StrEnum(str, Enum):
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ description = "Open Language Model (OLMo)"
 authors = [
     { name = "Allen Institute for Artificial Intelligence", email = "olmo@allenai.org" }
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.8"
 license = { file = "LICENSE" }
 dependencies = [
     "numpy",


### PR DESCRIPTION
The OLMo doesn't work with Python 3.8. This is because cache is not available before Python 3.9 in functools and MutableMapping from  collections.abc doesn't work with  Python 3.8 as described [issue 446](https://github.com/allenai/OLMo/issues/446)