### PR TITLE
Only rank0 log metrics to console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Removed `AMDLayerNorm`, since the original layer norm bug has been fixed and we don't need this workaround anymore.
 
+### Fixed
+
+- Don't log garbage on nodes that aren't rank 0
+
 
 ## [v0.2.5](https://github.com/allenai/OLMo/releases/tag/v0.2.5) - 2024-03-06
 

--- a/olmo/train.py
+++ b/olmo/train.py
@@ -958,8 +958,11 @@ class Trainer:
                         metrics.update(lr_monitor.check())
 
                     # Log metrics to console.
-                    if self.global_step % self.cfg.console_log_interval == 0 and get_global_rank() == 0:
-                        self.log_metrics_to_console(f"[step={self.global_step}/{self.max_steps}]", metrics)
+                    if self.global_step % self.cfg.console_log_interval == 0:
+                        if get_global_rank() == 0:
+                            self.log_metrics_to_console(f"[step={self.global_step}/{self.max_steps}]", metrics)
+                        else:
+                            log.info(f"[step={self.global_step}/{self.max_steps}]")
 
                     # Log metrics to W&B.
                     if (

--- a/olmo/train.py
+++ b/olmo/train.py
@@ -958,7 +958,7 @@ class Trainer:
                         metrics.update(lr_monitor.check())
 
                     # Log metrics to console.
-                    if self.global_step % self.cfg.console_log_interval == 0:
+                    if self.global_step % self.cfg.console_log_interval == 0 and get_global_rank() == 0:
                         self.log_metrics_to_console(f"[step={self.global_step}/{self.max_steps}]", metrics)
 
                     # Log metrics to W&B.


### PR DESCRIPTION
I use `python -m torch.distributed.run  xxx` to launch the training processes. If `reduce_global_loss` is `True`, only `rank0` reduces global loss and other ranks doesn't  reduce. The metrics logging to console by different ranks are confusing.  
```
train/CrossEntropyLoss=0.0370
train/Perplexity=1.038
throughput/total_tokens=181,873,410,048
throughput/device/tokens_per_second=14,991
throughput/device/batches_per_second=0.2288
2024-02-12 15:14:50,866 - olmo.train - INFO - [step=43362/739328]
train/CrossEntropyLoss=0.0380
train/Perplexity=1.039
throughput/total_tokens=181,873,410,048
throughput/device/tokens_per_second=14,991
throughput/device/batches_per_second=0.2288
2024-02-12 15:14:50,866 - olmo.train - INFO - [step=43362/739328]
train/CrossEntropyLoss=0.0378
train/Perplexity=1.039
throughput/total_tokens=181,873,410,048
throughput/device/tokens_per_second=14,991
throughput/device/batches_per_second=0.2288
2024-02-12 15:14:50,866 - olmo.train - INFO - [step=43362/739328]
train/CrossEntropyLoss=0.0383
train/Perplexity=1.039
throughput/total_tokens=181,873,410,048
throughput/device/tokens_per_second=14,991
throughput/device/batches_per_second=0.2288
2024-02-12 15:14:50,866 - olmo.train - INFO - [step=43362/739328]
train/CrossEntropyLoss=2.421
train/Perplexity=11.25
throughput/total_tokens=181,873,410,048
throughput/device/tokens_per_second=14,991
throughput/device/batches_per_second=0.2288
```

Only `rank0` should log metrics to console.