### PR TITLE
Cherry-pick FSDP wrap patch from #443

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -127,6 +127,7 @@ jobs:
           spec: |
             version: v2
             description: GPU Tests
+            budget: ai2/oe-training
             tasks:
               - name: tests
                 image:


### PR DESCRIPTION
Within the FSDP wrapping function, the \"recurse\" mode does not behave as
expected (for large models anyway). In particular it seems like there's
an inherent \"sized-based\" policy being applied that ignores our intent
to stop recursing down the module tree at, for example, the level of an
transformer block.

The API for wrapping functions itself is pretty simple, so I can't imagine how we'd
be interpreting it wrong. I suspect this another FSDP bug.