### PR TITLE
Only run the profiler through a single cycle

### DIFF
--- a/olmo/train.py
+++ b/olmo/train.py
@@ -877,7 +877,7 @@ class Trainer:
         if self.cfg.torch_profiling and get_global_rank() == 0:
             from torch.profiler import schedule
 
-            profiling_schedule = schedule(wait=1, warmup=5, active=3)
+            profiling_schedule = schedule(wait=1, warmup=5, active=3, repeat=1)
 
             def on_trace_ready(p):
                 profiler_output_dir = Path(self.cfg.save_folder) / "profiler"


### PR DESCRIPTION
We were missing the `repeat` argument to the scheduler, which explains
why the profiler would keep cycling indefinitely.