### PR TITLE
Add MMLU downstream tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added `output_hidden_states` argument and associated functionality to `OLMo` and `OLMoForCausalLM` to return model intermediate hidden states.
+- Added MMLU downstream evaluation tasks.
 
 ## [v0.2.4](https://github.com/allenai/OLMo/releases/tag/v0.2.4) - 2024-02-02
 

--- a/docs/Kempner.md
+++ b/docs/Kempner.md
@@ -34,5 +34,8 @@ Getting started
     from olmo.eval.downstream import *
     tokenizer = Tokenizer.from_file("tokenizers/allenai_eleuther-ai-gpt-neox-20b-pii-special.json")
     for x in label_to_task_map.values():
-      x(tokenizer=tokenizer)
+        kwargs = {}
+        if isinstance(x, tuple):
+            x, kwargs = x
+        x(tokenizer=tokenizer, **kwargs)
     ```

--- a/olmo/eval/__init__.py
+++ b/olmo/eval/__init__.py
@@ -31,8 +31,7 @@ def build_downstream_evaluator(
     task_kwargs = {}
     task_class = label_to_task_map[eval_cfg.label]
     if isinstance(task_class, tuple):
-        task_class = task_class[0]
-        task_kwargs = task_class[1]
+        task_class, task_kwargs = task_class
     ds_eval_dataset = task_class(tokenizer=tokenizer, **task_kwargs)  # type: ignore
     data_config = eval_cfg.data
     if is_unit_test:

--- a/olmo/eval/__init__.py
+++ b/olmo/eval/__init__.py
@@ -28,8 +28,12 @@ def build_downstream_evaluator(
     device: torch.device,
     is_unit_test=False,
 ) -> Evaluator:
+    task_kwargs = {}
     task_class = label_to_task_map[eval_cfg.label]
-    ds_eval_dataset = task_class(tokenizer=tokenizer)  # type: ignore
+    if isinstance(task_class, tuple):
+        task_class = task_class[0]
+        task_kwargs = task_class[1]
+    ds_eval_dataset = task_class(tokenizer=tokenizer, **task_kwargs)  # type: ignore
     data_config = eval_cfg.data
     if is_unit_test:
         ds_eval_sampler = None

--- a/olmo/eval/downstream.py
+++ b/olmo/eval/downstream.py
@@ -161,9 +161,10 @@ class ICLMultiChoiceTaskDataset(metaclass=abc.ABCMeta):
         self.model_ctx_len = model_ctx_len
 
         self.samples: List[Dict[str, Any]] = []
-        dataset_names = dataset_name
         if isinstance(dataset_name, str) or dataset_name is None:
             dataset_names = [dataset_name]
+        else:
+            dataset_names = dataset_name
 
         dataset_list = []
         for ds_name in dataset_names:

--- a/olmo/eval/downstream.py
+++ b/olmo/eval/downstream.py
@@ -149,7 +149,7 @@ class ICLMultiChoiceTaskDataset(metaclass=abc.ABCMeta):
         self,
         tokenizer: Tokenizer,
         dataset_path: str,
-        dataset_name: Optional[Union[str, list]] = None,
+        dataset_name: Optional[Union[str, List[str]]] = None,
         model_ctx_len: int = 2048,
         split="validation",
     ):
@@ -167,11 +167,13 @@ class ICLMultiChoiceTaskDataset(metaclass=abc.ABCMeta):
 
         dataset_list = []
         for ds_name in dataset_names:
-            dataset_list.append(datasets.load_dataset(
-                path=self.dataset_path,
-                name=ds_name,
-                split=split,
-            ))
+            dataset_list.append(
+                datasets.load_dataset(
+                    path=self.dataset_path,
+                    name=ds_name,
+                    split=split,
+                )
+            )
         self.dataset = datasets.concatenate_datasets(dataset_list)
 
         # prep examples
@@ -972,14 +974,14 @@ class SST2(ICLMultiChoiceTaskDataset):
 
 class MMLU(ICLMultiChoiceTaskDataset):
     """MMLU creates context with "Question: QUESTION\nAnswer:" and sends the choices as continuations
-        space added as prefix to each continuation
+           space added as prefix to each continuation
 
-    {
-        'question': "Which of the following terms describes the body's ability to maintain its normal state?",
-        'subject': 'anatomy',
-        'choices': ['Anabolism', 'Catabolism', 'Tolerance', 'Homeostasis'],
- '       answer': 3
-     }
+       {
+           'question': "Which of the following terms describes the body's ability to maintain its normal state?",
+           'subject': 'anatomy',
+           'choices': ['Anabolism', 'Catabolism', 'Tolerance', 'Homeostasis'],
+    '       answer': 3
+        }
     """
 
     metric_type = "len_norm"  # Ideally pmi_dc
@@ -1065,12 +1067,7 @@ class MMLU(ICLMultiChoiceTaskDataset):
             for name, cats in MMLU._subcategories.items():
                 if dataset_name in cats:
                     dataset_names.append(name)
-        super().__init__(
-            tokenizer=tokenizer,
-            dataset_path=dataset_path,
-            dataset_name=dataset_names,
-            split=split
-        )
+        super().__init__(tokenizer=tokenizer, dataset_path=dataset_path, dataset_name=dataset_names, split=split)
 
     def doc_to_text(self, doc):
         return "Question: " + doc["question"] + "\nAnswer:"
@@ -1080,7 +1077,7 @@ class MMLU(ICLMultiChoiceTaskDataset):
         return [" " + choice for choice in doc["choices"]]
 
     def doc_to_label(self, doc):
-        return doc['answer']
+        return doc["answer"]
 
     def doc_to_domain_conditional(self, doc):
         del doc

--- a/olmo/eval/downstream.py
+++ b/olmo/eval/downstream.py
@@ -1,6 +1,6 @@
 import abc
 import re
-from typing import Any, ClassVar, Dict, List, Optional, Union, Sequence
+from typing import Any, ClassVar, Dict, List, Optional, Sequence, Union
 
 import datasets
 import torch

--- a/olmo/eval/downstream.py
+++ b/olmo/eval/downstream.py
@@ -594,7 +594,7 @@ class BoolQ(ICLMultiChoiceTaskDataset):
     }
     """
 
-    metric_type = "pmi_dc"
+    metric_type = "acc"
 
     def __init__(self, tokenizer, dataset_path="boolq", dataset_name=None):
         super().__init__(
@@ -716,7 +716,7 @@ class ArcChallenge(ArcEasy):
     implement PMI_DC
     """
 
-    metric_type = "pmi_dc"
+    metric_type = "len_norm"  # Ideally "pmi_dc"
 
     def __init__(self, tokenizer, dataset_path="ai2_arc", dataset_name="ARC-Challenge"):
         super().__init__(

--- a/olmo/eval/downstream.py
+++ b/olmo/eval/downstream.py
@@ -1,6 +1,6 @@
 import abc
 import re
-from typing import Any, ClassVar, Dict, List, Optional, Union
+from typing import Any, ClassVar, Dict, List, Optional, Union, Sequence
 
 import datasets
 import torch
@@ -149,7 +149,7 @@ class ICLMultiChoiceTaskDataset(metaclass=abc.ABCMeta):
         self,
         tokenizer: Tokenizer,
         dataset_path: str,
-        dataset_name: Optional[Union[str, List[str]]] = None,
+        dataset_name: Union[str, Sequence[str], None] = None,
         model_ctx_len: int = 2048,
         split="validation",
     ):
@@ -161,6 +161,7 @@ class ICLMultiChoiceTaskDataset(metaclass=abc.ABCMeta):
         self.model_ctx_len = model_ctx_len
 
         self.samples: List[Dict[str, Any]] = []
+        dataset_names: Sequence[Optional[str]]
         if isinstance(dataset_name, str) or dataset_name is None:
             dataset_names = [dataset_name]
         else:

--- a/olmo/eval/downstream.py
+++ b/olmo/eval/downstream.py
@@ -1,6 +1,6 @@
 import abc
 import re
-from typing import Any, ClassVar, Dict, List, Optional
+from typing import Any, ClassVar, Dict, List, Optional, Union
 
 import datasets
 import torch
@@ -149,7 +149,7 @@ class ICLMultiChoiceTaskDataset(metaclass=abc.ABCMeta):
         self,
         tokenizer: Tokenizer,
         dataset_path: str,
-        dataset_name: Optional[str] = None,
+        dataset_name: Optional[Union[str, list]] = None,
         model_ctx_len: int = 2048,
         split="validation",
     ):
@@ -161,7 +161,9 @@ class ICLMultiChoiceTaskDataset(metaclass=abc.ABCMeta):
         self.model_ctx_len = model_ctx_len
 
         self.samples: List[Dict[str, Any]] = []
-        dataset_names = [dataset_name] if isinstance(dataset_name, str) else dataset_name
+        dataset_names = dataset_name
+        if isinstance(dataset_name, str) or dataset_name is None:
+            dataset_names = [dataset_name]
 
         dataset_list = []
         for ds_name in dataset_names:


### PR DESCRIPTION
Together with @yulinggu-cs, we added the following tasks from MMLU to the in-loop downstream evaluation suite:

Validation sets:
   * mmlu_stem (321 qs)
   * mmlu_humanities (518 qs)
   * mmlu_social_sciences (337 qs)
   * mmlu_other (355 qs)

Test sets:
   * mmlu_stem_test (3018 qs)
   * mmlu_humanities_test (4705 qs)
   * mmlu_social_sciences_test (3077 qs)
   * mmlu_other_test (3242 qs)

We also updated the `metric_type` for `boolq` and `arc_challenge` from "pmi_dc" to "acc" and "len_norm". These are generally correlated, although ideally "pmi_dc" would be used for several datasets once it's properly implemented.  `boolq` should be fine with "acc" though.

Note that this adds some processing time at startup.