### PR TITLE
hf_olmo: support flash attn 2

### DIFF
--- a/hf_olmo/modeling_olmo.py
+++ b/hf_olmo/modeling_olmo.py
@@ -33,6 +33,7 @@ class OLMoForCausalLM(PreTrainedModel):
     config_class = OLMoConfig
     base_model_prefix = "model"
     _no_split_modules = ["OLMoBlock"]
+    _supports_flash_attn_2 = True
 
     def __init__(self, config: OLMoConfig, model: Optional[Olmo] = None, init_params: bool = False):
         super().__init__(config)


### PR DESCRIPTION
https://github.com/allenai/OLMo/issues/460, tested with a simple snippet as below:

```
import transformers, torch

model = transformers.AutoModelForCausalLM.from_pretrained("allenai/OLMo-7B-Instruct", use_flash_attention_2="flash_attention_2", trust_remote_code=True).cuda()
tokenizer = transformers.AutoTokenizer.from_pretrained("allenai/OLMo-7B-Instruct", trust_remote_code=True)

print(tokenizer.decode(model.generate(torch.tensor(tokenizer.encode("Hello World! My name is")).unsqueeze(0).cuda())[0]))
# Hello World! My name is Emily and I am a second year student at the University of California,
```