### PR TITLE
Add support for PyTorch v2.2

### DIFF
--- a/olmo/checkpoint.py
+++ b/olmo/checkpoint.py
@@ -34,8 +34,12 @@ from torch.distributed.fsdp.api import (
     ShardedOptimStateDictConfig,
     ShardedStateDictConfig,
 )
-from torch.distributed.fsdp.flat_param import FlatParamHandle
 from torch.futures import Future
+
+try:
+    from torch.distributed.fsdp.flat_param import FlatParamHandle  # type: ignore
+except ModuleNotFoundError:
+    from torch.distributed.fsdp._flat_param import FlatParamHandle  # type: ignore
 
 from .aliases import PathOrStr
 from .config import BaseConfig, ShardedCheckpointerType, TrainConfig
@@ -1124,6 +1128,8 @@ class LocalShardedCheckpointer(Checkpointer):
                 return [fsdp_model._handle]  # type: ignore
             else:
                 return []
+        elif version.parse(torch.__version__) < version.parse("2.3.0"):
+            return fsdp_model._all_handles
         else:
             # Need to verify FSDP internals with newer versions.
             raise NotImplementedError

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ requires-python = ">=3.8"
 license = { file = "LICENSE" }
 dependencies = [
     "numpy",
-    "torch>=2.0,<2.2",
+    "torch>=2.0,<2.3",
     "omegaconf",
     "rich",
     "boto3",


### PR DESCRIPTION
The main blocker was making sure our hacked-together `LocalShardedCheckpointer` class was updated to account for the recent changes to FSDP internals. I've verified that this checkpointer still works correctly. Here is a restart that reproduces the original loss curve perfectly:

![image](https://github.com/allenai/OLMo/assets/8812459/24869d47-9bac-4b4c-a5f0-5b73e81845f2)

See https://wandb.ai/ai2-llm/torch-22-testing?workspace=user-epwalsh for full logs.