### PR TITLE
Add MMLU prompt variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added `output_hidden_states` argument and associated functionality to `OLMo` and `OLMoForCausalLM` to return model intermediate hidden states.
-- Added MMLU downstream evaluation tasks.
+- Added MMLU downstream evaluation tasks, with prompt variations.
 - Added support for PyTorch v2.2.
 
 ## [v0.2.4](https://github.com/allenai/OLMo/releases/tag/v0.2.4) - 2024-02-02

--- a/olmo/eval/downstream.py
+++ b/olmo/eval/downstream.py
@@ -1118,8 +1118,8 @@ class MMLU(ICLMultiChoiceTaskDataset):
             if num_shots:
                 dev_set = self.dev_set.get(doc.get('subject'), [])
                 for dev_doc in dev_set[:int(num_shots[0])]:
-                    answer = dev_doc["choices"][doc["answer"]]
-                    prefix += "Question: " + doc["question"] + "\nAnswer: " + answer + "\n\n"
+                    answer = dev_doc["choices"][dev_doc["answer"]]
+                    prefix += "Question: " + dev_doc["question"] + "\nAnswer: " + answer + "\n\n"
             output_text = prefix + output_text
         return output_text
 

--- a/olmo/eval/downstream.py
+++ b/olmo/eval/downstream.py
@@ -1117,7 +1117,7 @@ class MMLU(ICLMultiChoiceTaskDataset):
             num_shots = re.findall("\\+(\\d+)", self.current_prompt)
             if num_shots:
                 dev_set = self.dev_set.get(doc.get('subject'), [])
-                for dev_doc in dev_set[:int(num_shots)]:
+                for dev_doc in dev_set[:int(num_shots[0])]:
                     answer = dev_doc["choices"][doc["answer"]]
                     prefix += "Question: " + doc["question"] + "\nAnswer: " + answer + "\n\n"
             output_text = prefix + output_text

--- a/olmo/eval/downstream.py
+++ b/olmo/eval/downstream.py
@@ -216,7 +216,10 @@ class ICLMultiChoiceTaskDataset(metaclass=abc.ABCMeta):
                 dc = self.token_encode(self.doc_to_domain_conditional(doc))
                 if self.log_instances > 0:
                     self.log_instances -= 1
-                    log.info(f"Sample doc from ({self.dataset_path}, {self.dataset_name}, {self.current_prompt}):" +
+                    ds_name = self.dataset_name
+                    if isinstance(ds_name, list):
+                        ds_name = ds_name[0]
+                    log.info(f"Sample doc from ({self.dataset_path}, {ds_name}, {self.current_prompt}):" +
                              f"\ndoc_text: {doc_text}\ncontinuations: {continuations}")
 
                 for cont_id, continuation_str in enumerate(continuations):
@@ -670,7 +673,7 @@ class SciQ(ICLMultiChoiceTaskDataset):
         )
 
     def doc_to_text(self, doc):
-        return doc["support"] + "\nQuestion: " + doc["question"] + "\nAnswer:".strip()
+        return doc["support"].strip() + "\nQuestion: " + doc["question"] + "\nAnswer:"
 
     def doc_to_continuations(self, doc):
         # add spaces in front of continuation
@@ -1091,14 +1094,18 @@ class MMLU(ICLMultiChoiceTaskDataset):
                     dataset_names.append(name)
         self.dev_set = {}
         if prompt_variations == 1:
-            self.prompts = [None, "inst", "inst+1", "inst+2", "inst+3", "inst+4", "inst+5"]
+            prompts = [None, "inst", "inst+1", "inst+2", "inst+3", "inst+4", "inst+5"]
             # Need to grab the dev set for the few-shot prompts
             for name in dataset_names:
                 self.dev_set[name] = datasets.load_dataset(path=dataset_path,
                                                            name=name,
                                                            split="dev",
                                                            trust_remote_code=True)
-        super().__init__(tokenizer=tokenizer, dataset_path=dataset_path, dataset_name=dataset_names, split=split)
+        super().__init__(tokenizer=tokenizer,
+                         dataset_path=dataset_path,
+                         dataset_name=dataset_names,
+                         split=split,
+                         prompts=prompts)
 
     def doc_to_text(self, doc):
         output_text = "Question: " + doc["question"] + "\nAnswer:"

--- a/olmo/eval/downstream.py
+++ b/olmo/eval/downstream.py
@@ -219,8 +219,10 @@ class ICLMultiChoiceTaskDataset(metaclass=abc.ABCMeta):
                     ds_name = self.dataset_name
                     if isinstance(ds_name, list):
                         ds_name = ds_name[0]
-                    log.info(f"Sample doc from ({self.dataset_path}, {ds_name}, {self.current_prompt}):" +
-                             f"\ndoc_text: {doc_text}\ncontinuations: {continuations}")
+                    log.info(
+                        f"Sample doc from ({self.dataset_path}, {ds_name}, {self.current_prompt}):"
+                        + f"\ndoc_text: {doc_text}\ncontinuations: {continuations}"
+                    )
 
                 for cont_id, continuation_str in enumerate(continuations):
                     cont_str_len = len(continuation_str) - 1  # continuation contain leading blank
@@ -1075,12 +1077,14 @@ class MMLU(ICLMultiChoiceTaskDataset):
         "other": ["other", "business", "health"],
     }
 
-    def __init__(self,
-                 tokenizer,
-                 dataset_path="hails/mmlu_no_train",
-                 dataset_name=None,
-                 split="validation",
-                 prompt_variations=None):
+    def __init__(
+        self,
+        tokenizer,
+        dataset_path="hails/mmlu_no_train",
+        dataset_name=None,
+        split="validation",
+        prompt_variations=None,
+    ):
         dataset_names = []
         # Collect the relevant categories
         if dataset_name in MMLU._categories:
@@ -1099,26 +1103,27 @@ class MMLU(ICLMultiChoiceTaskDataset):
             prompts = [None, "inst", "inst+1", "inst+2", "inst+3", "inst+4", "inst+5"]
             # Need to grab the dev set for the few-shot prompts
             for name in dataset_names:
-                self.dev_set[name] = datasets.load_dataset(path=dataset_path,
-                                                           name=name,
-                                                           split="dev",
-                                                           trust_remote_code=True)
-        super().__init__(tokenizer=tokenizer,
-                         dataset_path=dataset_path,
-                         dataset_name=dataset_names,
-                         split=split,
-                         prompts=prompts)
+                self.dev_set[name] = datasets.load_dataset(
+                    path=dataset_path, name=name, split="dev", trust_remote_code=True
+                )
+        super().__init__(
+            tokenizer=tokenizer,
+            dataset_path=dataset_path,
+            dataset_name=dataset_names,
+            split=split,
+            prompts=prompts,
+        )
 
     def doc_to_text(self, doc):
         output_text = "Question: " + doc["question"] + "\nAnswer:"
         if self.current_prompt is not None:
             prefix = ""
             if "inst" in self.current_prompt:
-                subject = doc.get('subject').replace("_", " ")
+                subject = doc.get("subject").replace("_", " ")
                 prefix = f"The following are multiple choice questions (with answers) about {subject}:\n\n"
             num_shots = re.findall("\\+(\\d+)", self.current_prompt)
             if num_shots:
-                dev_set = self.dev_set.get(doc.get('subject'), [])
+                dev_set = self.dev_set.get(doc.get("subject"), [])
                 num_shots_int = int(num_shots[0])
                 for idx, dev_doc in enumerate(dev_set):
                     if idx >= num_shots_int:

--- a/olmo/eval/downstream.py
+++ b/olmo/eval/downstream.py
@@ -1117,7 +1117,10 @@ class MMLU(ICLMultiChoiceTaskDataset):
             num_shots = re.findall("\\+(\\d+)", self.current_prompt)
             if num_shots:
                 dev_set = self.dev_set.get(doc.get('subject'), [])
-                for dev_doc in dev_set[:int(num_shots[0])]:
+                num_shots_int = int(num_shots[0])
+                for idx, dev_doc in enumerate(dev_set):
+                    if idx >= num_shots_int:
+                        break
                     answer = dev_doc["choices"][dev_doc["answer"]]
                     prefix += "Question: " + dev_doc["question"] + "\nAnswer: " + answer + "\n\n"
             output_text = prefix + output_text

--- a/olmo/eval/downstream.py
+++ b/olmo/eval/downstream.py
@@ -229,6 +229,8 @@ class ICLMultiChoiceTaskDataset(metaclass=abc.ABCMeta):
                     # query, remove last token from continuation, truncate from left is longer than model ctx length
                     query = ctx + continuation[:-1]
                     query = query[-self.model_ctx_len :]
+                    # this will be different from len(ctx) when truncated by model_ctx_len
+                    actual_ctx_len = len(query) - len(continuation) + 1
 
                     # get domain conditional query
                     # we don't expect this to be longer than self.model_ctx_len and it won't make sense to truncate from left
@@ -241,7 +243,7 @@ class ICLMultiChoiceTaskDataset(metaclass=abc.ABCMeta):
                             "cont_id": cont_id,
                             "ctx": ctx,
                             "continuation": continuation,
-                            "ctx_len": len(ctx),
+                            "ctx_len": actual_ctx_len,
                             "dc_len": len(dc),
                             "cont_len": len(
                                 continuation


### PR DESCRIPTION
With @yulinggu-cs, added a version of the MMLU datasets with multiple prompt variants, to make the datasets effectively 7x larger. These are named `mmlu_stem_var` etc (add `_var` suffix).

The prompts are called: `[None, "inst", "inst+1", "inst+2", "inst+3", "inst+4", "inst+5"]`

where "inst+2" means add instruction line followed by 2-shot example. We also added logging of first few examples for each downstream task (can remove this if it's annoying, but it's a useful sanity check), here's an example for the "inst+2" prompt:
```
[2024-03-04 19:06:09] INFO     [olmo.eval.downstream:224, rank=0] Sample doc from (hails/mmlu_no_train, high_school_government_and_politics, inst+2):
doc_text: The following are multiple choice questions (with answers) about high school government and politics:

Question: Uncertainty over the limits to presidential power is caused primarily by the fact that
Answer: the constitutional definition of those powers is broad and unspecific

Question: The term "budget deficit" refers to the
Answer: amount the government spends in excess of its revenues

Question: Which of the following accurately describes congressional committees? I. The committee chairpersons always belong to the majority party. II. Seats on each committee are divided between the two major parties in exact proportion to the parties' representation in Congress. III. They recommend whether Congress should pass various pieces of legislation, and those recommendations are always approved by the full congressional body. IV. When a committee vote results in a tie, the vice president casts the tie-breaking vote.
Answer:
continuations: [' I only', ' II only', ' I and III only', ' II and III only']
```

Things to note:
   * There was a bug when an instance goes beyond max context length, as the computation in `update` uses `batch["ctx_len"]` which might be larger than 2048. I tried to fix this in https://github.com/allenai/OLMo/commit/f64b9ce1dffe6f5c61ad582f8c731a85c47f4c17, but it's a bit iffy (the context length is separately processed in `prep_examples` and in `collate_fn` which could be confusing
   * Logging the instances we noticed a tiny issue with the SciQ formatting, fixed [here](https://github.com/allenai/OLMo/commit/dff32c6882ccbc53a47a125f31efb6b0201db2b0#diff-cf39bf0a6cccecf47af2cebf6e33f2e452d7c66857aee654e5c0736b3f7aed4aL673)
   * As mentioned, we the first 5 instances in each dataset. If this happens in some sort of parallel processing, the method of doing `self.log_instances -= 1` might not be very robust? If this is too noisy in the logging, we can comment these lines out.
  