### PR TITLE
[Storage Cleaner] Speed up unsharding of some legacy checkpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,11 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for PyTorch v2.2.
 - Added ability to show logs from all ranks
 
-
-
 ### Changed
 
-- Refactor torch.load monkey patching for legacy checkpoint unsharding in anticipation of unsharding implementation change.
+- Changed legacy checkpoint unsharding to use processes and shared memory instead of threads
 
 ## [v0.2.4](https://github.com/allenai/OLMo/releases/tag/v0.2.4) - 2024-02-02
 


### PR DESCRIPTION
This PR changes the unsharding mechanism of legacy checkpoints to use processes and shared memory instead of threads. In one case where the world size was 1024, this implementation brought the unsharding time down from 6 hours to 30 minutes. This implementation is slower than the old one at smaller scales, but that is ok.

An option was to keep the old mechanism around in code too, but since we are trying to get rid of legacy sharded checkpoints it doesn't seem worth to keep that code around.