### PR TITLE
Remove AMD LayerNorm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Changed legacy checkpoint unsharding to use processes and shared memory instead of threads
 
+### Removed
+
+- Removed `AMDLayerNorm`, since the original layer norm bug has been fixed and we don't need this workaround anymore.
+
+
 ## [v0.2.4](https://github.com/allenai/OLMo/releases/tag/v0.2.4) - 2024-02-02
 
 ### Fixed

--- a/olmo/config.py
+++ b/olmo/config.py
@@ -171,11 +171,6 @@ class LayerNormType(StrEnum):
     probably the fastest implementation.
     """
 
-    amd_compatible = "amd_compatible"
-    """
-    LayerNorm implemented manually to work around an issue with ROCm.
-    """
-
 
 class ActivationType(StrEnum):
     gelu = "gelu"

--- a/tests/model_test.py
+++ b/tests/model_test.py
@@ -6,7 +6,6 @@ from torch.nn import CrossEntropyLoss
 from olmo import BlockType, LayerNorm, Olmo, Tokenizer, TrainConfig
 from olmo.config import ModelConfig, PaddingDirection
 from olmo.data import DataCollator
-from olmo.model import AMDLayerNorm
 
 
 @pytest.mark.parametrize(
@@ -399,7 +398,6 @@ def test_layer_norm(train_config: TrainConfig, elementwise_affine: bool, include
     train_config.model.layer_norm_with_affine = elementwise_affine
     train_config.model.include_bias = include_bias
     ln = LayerNorm.build(train_config.model)
-    amd_ln = AMDLayerNorm(train_config.model)
 
     needs_weight = elementwise_affine
     needs_bias = elementwise_affine and include_bias
@@ -407,30 +405,23 @@ def test_layer_norm(train_config: TrainConfig, elementwise_affine: bool, include
         if needs_weight:
             weight = torch.randn(train_config.model.d_model)
             ln.weight.copy_(weight)
-            amd_ln.weight.copy_(weight)
         else:
             weight = None
 
         if needs_bias:
             bias = torch.randn(train_config.model.d_model)
             ln.bias.copy_(bias)
-            amd_ln.bias.copy_(bias)
         else:
             bias = None
 
     assert ln.bias is None or ln.bias.requires_grad == needs_bias
     assert ln.weight is None or ln.weight.requires_grad == needs_weight
-    assert amd_ln.bias is None or amd_ln.bias.requires_grad == needs_bias
-    assert amd_ln.weight is None or amd_ln.weight.requires_grad == needs_weight
 
     x = torch.randn(16, 1024, train_config.model.d_model)
     x.requires_grad = False
     y_expected = F.layer_norm(x, [train_config.model.d_model], weight, bias)
 
     y_actual = ln(x)
-    torch.testing.assert_close(y_actual, y_expected)
-
-    y_actual = amd_ln(x)
     torch.testing.assert_close(y_actual, y_expected)
 
 


### PR DESCRIPTION
The original bug has been fixed and we don't need this workaround anymore.

Closes #437.