### PR TITLE
[Storage Cleaner] Improvements to moving runs

### DIFF
--- a/scripts/storage_cleaner.py
+++ b/scripts/storage_cleaner.py
@@ -1192,9 +1192,7 @@ def _get_src_dest_pairs_for_copy(
     checkpoint_dirs = _get_checkpoint_dirs(run_dir, run_dir_storage)
     # TODO: Update _get_wandb_path to get the wandb path for a checkpoint rather than a run directory.
     # A run directory could correspond to multiple wandb runs.
-    checkpoint_to_wandb_path = {
-        checkpoint_dir: _get_wandb_path(run_dir) for checkpoint_dir in checkpoint_dirs
-    }
+    checkpoint_to_wandb_path = {checkpoint_dir: _get_wandb_path(run_dir) for checkpoint_dir in checkpoint_dirs}
 
     src_dest_pairs: List[Tuple[str, str]] = []
     # Mappings of source checkpoint directories to destination checkpoint directories
@@ -1205,7 +1203,7 @@ def _get_src_dest_pairs_for_copy(
 
     # Mappings of other source entries to destination entries. Since different checkpoints
     # may comes from different wandb runs, we need to map non-checkpoint entries to
-    # every folder corresponding to a wandb run of these checkpoints. 
+    # every folder corresponding to a wandb run of these checkpoints.
     src_dest_pairs += [
         (os.path.join(run_dir, entry), os.path.join(dest_dir, wandb_path, entry))
         for entry in run_dir_storage.list_entries(run_dir)
@@ -1233,7 +1231,9 @@ def _move_run(src_storage: StorageAdapter, run_dir_or_archive: str, dest_dir: st
                 log.info("Source and destination move paths are both %s, skipping", src_move_path)
                 continue
             else:
-                raise RuntimeError(f"Source and destination move paths are both {src_move_path} and source is being deleted")
+                raise RuntimeError(
+                    f"Source and destination move paths are both {src_move_path} and source is being deleted"
+                )
 
         if config.dry_run:
             log.info("Would copy %s to %s", src_move_path, dest_move_path)


### PR DESCRIPTION
This is the first of 3 PRs that make changes to the move mechanism of the storage cleaner. The other PRs will:
1. Add the option to move just 1 entry from a run, making the script more parallelizable.
2. Migrate off `TrainConfig` to support legacy checkpoints.

This PR makes the following changes:

- Adds most of the functionality for moving non-checkpoint entries when `append_wandb_path` is set. This will make it possible to upload `train_data` to all folders that need it.
- Lets the storage adapter choose what happens when moving an entry to a destination where the entry already exists. This change is not necessary but is convenient.