### PR TITLE
Add basic arithmetic task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for PyTorch v2.2.
 - Added ability to show logs from all ranks
 - Added option for QKV clipping.
+- Added basic_arithmetic downstream evaluation task
 
 ### Changed
 

--- a/olmo/eval/downstream.py
+++ b/olmo/eval/downstream.py
@@ -754,6 +754,27 @@ class ArcChallenge(ArcEasy):
         )
 
 
+class BasicArithmetic(ArcEasy):
+    """This is a basic arithmetic task follows the same prompt format as ArcEasy.
+    Example:
+    {"id": "q85_1d1d_max1d_plus",
+    "question": "Calculate 2 + 5 =",
+    "choices": {"text": ["8", "7", "6", "17"],
+    "label": ["A", "B", "C", "D"]},
+    "answerKey": "B", "type_tag": "easy"}
+
+    """
+
+    metric_type = "acc"
+
+    def __init__(self, tokenizer, dataset_path="allenai/basic_arithmetic", dataset_name=None):
+        super().__init__(
+            tokenizer=tokenizer,
+            dataset_path=dataset_path,
+            dataset_name=dataset_name,
+        )
+
+
 class COPA(ICLMultiChoiceTaskDataset):
     """Prompt: "PREMISE.strip()[:-1] because/therefore"
     Req_loglikelihood('The pair of students came under scrutiny by the teacher because', ' the students both received excellent grades.'
@@ -1154,6 +1175,7 @@ label_to_task_map = {
     "sciq": SciQ,
     "arc_easy": ArcEasy,
     "arc_challenge": ArcChallenge,
+    "basic_arithmetic": BasicArithmetic,
     "copa": COPA,
     "rte": RTE,
     "commitment_bank": CommitmentBank,


### PR DESCRIPTION
Added `basic_arithmetic` as downstream evaluation task, example instance:
```
 {"id": "q85_1d1d_max1d_plus", "question": "Calculate 2 + 5 =",
    "choices": {"text": ["8", "7", "6", "17"], "label": ["A", "B", "C", "D"]},
    "answerKey": "B", "type_tag": "easy"}
```
To include in a training config, use:
```
  - label: basic_arithmetic
    type: downstream
```