### PR TITLE
Change tie_weights to no-op and add docstring for weight tying clarification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed `AMDLayerNorm`, since the original layer norm bug has been fixed and we don't need this workaround anymore.
 
 ### Fixed
+
 - Don't log garbage on nodes that aren't rank 0
 - Don't crash in the HF code when we are referring to a tokenizer in a local file
 - Changed `tie_weights` method to a no-op as weight tying is handled in olmo/model.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed `AMDLayerNorm`, since the original layer norm bug has been fixed and we don't need this workaround anymore.
 
 ### Fixed
-
 - Don't log garbage on nodes that aren't rank 0
 - Don't crash in the HF code when we are referring to a tokenizer in a local file
+- Changed `tie_weights` method to a no-op as weight tying is handled in olmo/model.py
 
 
 ## [v0.2.5](https://github.com/allenai/OLMo/releases/tag/v0.2.5) - 2024-03-06

--- a/hf_olmo/modeling_olmo.py
+++ b/hf_olmo/modeling_olmo.py
@@ -148,8 +148,18 @@ class OLMoForCausalLM(PreTrainedModel):
             self.model.transformer.ff_out = value
 
     def tie_weights(self):
-        if self.config.weight_tying:
-            self.model.transformer.ff_out = self.model.transformer.wte
+        """
+        This function is intentionally left as a no-op.
+
+        Weight tying is handled as follows:
+        - When the model is initialized, the `ff_out` layer is conditionally defined based on the `weight_tying` configuration.
+        See: `if not config.weight_tying: self.transformer.update(...)` in `olmo/model.py`.
+        - When computing logits, the `wte` weights are used directly if `weight_tying` is enabled.
+        See: `if self.config.weight_tying: logits = F.linear(x, self.transformer.wte.weight, None)` in the `forward` method.
+
+        Therefore, there is no need to explicitly tie the weights in this function.
+        """
+        pass
 
 
 # Register the model so that it is available for transformer pipelines, auto-loading, etc.


### PR DESCRIPTION
This pull request addresses #485 and updates the `tie_weights` function in the `OLMoForCausalLM` class to be a no-op and adds a docstring explaining the reasoning behind this change.

The `tie_weights` function is being made a no-op because weight tying is already handled explicitly in other parts of the codebase. This change avoids redundant weight tying logic and improves code clarity.

The added docstring explains why the function is a no-op and directs developers to the specific locations where weight tying is handled. This improves code readability and maintainability.

This doesn't fix the warning message from the `accelerate` library, which expects a fundamentally different mechanism for weight tying.

@2015aroras ready for your initial review—thanks!
