### PR TITLE
Add reorder cache for beam search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- Added _reorder_cache function to enable beam search when generating with HF
 
 ### Added
 

--- a/hf_olmo/modeling_olmo.py
+++ b/hf_olmo/modeling_olmo.py
@@ -126,8 +126,15 @@ class OLMoForCausalLM(PreTrainedModel):
     # def get_position_embeddings(self) -> Union[nn.Embedding, Tuple[nn.Embedding]]:
     #     pass
     #
-    # def _reorder_cache(self, past_key_values, beam_idx):
-    #     pass
+
+    def _reorder_cache(self, past_key_values: Tuple[Tuple[torch.Tensor]], beam_idx: torch.Tensor
+    ) -> Tuple[Tuple[torch.Tensor]]:
+        reordered_past = ()
+        for layer_past in past_key_values:
+            reordered_past += (
+                tuple(past_state.index_select(0, beam_idx.to(past_state.device)) for past_state in layer_past),
+            )
+        return reordered_past
 
     def get_input_embeddings(self) -> torch.nn.Module:
         return self.model.transformer.wte

--- a/olmo/optim.py
+++ b/olmo/optim.py
@@ -723,9 +723,9 @@ def build_scheduler(cfg: TrainConfig, sched_cfg: Optional[SchedulerConfig] = Non
     sched_cfg = sched_cfg if sched_cfg is not None else cfg.scheduler
     if sched_cfg.name == SchedulerType.cosine_with_warmup:
         return CosWithWarmup(
-            grad_clip_warmup_steps=None
-            if sched_cfg.grad_clip_warmup_steps is None
-            else int(sched_cfg.grad_clip_warmup_steps),
+            grad_clip_warmup_steps=(
+                None if sched_cfg.grad_clip_warmup_steps is None else int(sched_cfg.grad_clip_warmup_steps)
+            ),
             grad_clip_warmup_factor=sched_cfg.grad_clip_warmup_factor,
             warmup_steps=int(sched_cfg.t_warmup),
             alpha_f=sched_cfg.alpha_f,
@@ -733,9 +733,9 @@ def build_scheduler(cfg: TrainConfig, sched_cfg: Optional[SchedulerConfig] = Non
         )
     elif sched_cfg.name == SchedulerType.linear_with_warmup:
         return LinearWithWarmup(
-            grad_clip_warmup_steps=None
-            if sched_cfg.grad_clip_warmup_steps is None
-            else int(sched_cfg.grad_clip_warmup_steps),
+            grad_clip_warmup_steps=(
+                None if sched_cfg.grad_clip_warmup_steps is None else int(sched_cfg.grad_clip_warmup_steps)
+            ),
             grad_clip_warmup_factor=sched_cfg.grad_clip_warmup_factor,
             warmup_steps=int(sched_cfg.t_warmup),
             alpha_f=sched_cfg.alpha_f,
@@ -743,26 +743,26 @@ def build_scheduler(cfg: TrainConfig, sched_cfg: Optional[SchedulerConfig] = Non
         )
     elif sched_cfg.name == SchedulerType.inverse_sqrt_with_warmup:
         return InvSqrtWithWarmup(
-            grad_clip_warmup_steps=None
-            if sched_cfg.grad_clip_warmup_steps is None
-            else int(sched_cfg.grad_clip_warmup_steps),
+            grad_clip_warmup_steps=(
+                None if sched_cfg.grad_clip_warmup_steps is None else int(sched_cfg.grad_clip_warmup_steps)
+            ),
             grad_clip_warmup_factor=sched_cfg.grad_clip_warmup_factor,
             warmup_steps=int(sched_cfg.t_warmup),
         )
     elif sched_cfg.name == SchedulerType.max_scheduler:
         return MaxScheduler(
-            grad_clip_warmup_steps=None
-            if sched_cfg.grad_clip_warmup_steps is None
-            else int(sched_cfg.grad_clip_warmup_steps),
+            grad_clip_warmup_steps=(
+                None if sched_cfg.grad_clip_warmup_steps is None else int(sched_cfg.grad_clip_warmup_steps)
+            ),
             grad_clip_warmup_factor=sched_cfg.grad_clip_warmup_factor,
             sched1=build_scheduler(cfg, replace(sched_cfg, name=SchedulerType.cosine_with_warmup)),
             sched2=build_scheduler(cfg, replace(sched_cfg, name=SchedulerType.inverse_sqrt_with_warmup)),
         )
     elif sched_cfg.name == SchedulerType.constant:
         return ConstantScheduler(
-            grad_clip_warmup_steps=None
-            if sched_cfg.grad_clip_warmup_steps is None
-            else int(sched_cfg.grad_clip_warmup_steps),
+            grad_clip_warmup_steps=(
+                None if sched_cfg.grad_clip_warmup_steps is None else int(sched_cfg.grad_clip_warmup_steps)
+            ),
             grad_clip_warmup_factor=sched_cfg.grad_clip_warmup_factor,
         )
     else:

--- a/scripts/add_code_eval.py
+++ b/scripts/add_code_eval.py
@@ -1,6 +1,7 @@
 """
 Script to create perplexity eval datasets for code.
 """
+
 import os
 
 import pandas as pd

--- a/scripts/init_config.py
+++ b/scripts/init_config.py
@@ -1,6 +1,7 @@
 """
 Run this to initialize a new training config to a file.
 """
+
 import logging
 import sys
 from pathlib import Path

--- a/scripts/show_model_size.py
+++ b/scripts/show_model_size.py
@@ -7,6 +7,7 @@ For example:
 python scripts/show_model_size.py train_config.yaml
 ```
 """
+
 import logging
 import sys
 


### PR DESCRIPTION
Missing implementation for _reorder_cache for the HF model. Added to run beam search with HF using the `num_beams` argument in model.generate(). 

(There are also some minor spacing updates added to files through the tests/linting following the guidelines for this repo!)  