### PR TITLE
Tokenizer patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added commonsense_qa and social_iqa downstream evaluation tasks
 - Makes it possible to read from http/https the same way we read from s3/r2.
 - Added MMLU multiple choice (A/B/C/D) 5-shot variant downstream tasks
+- Tokenizer patch
 
 ### Changed
 

--- a/hf_olmo/convert_olmo_to_hf.py
+++ b/hf_olmo/convert_olmo_to_hf.py
@@ -91,12 +91,14 @@ def download_remote_checkpoint_and_convert_to_hf(checkpoint_dir: str, local_dir:
     convert_checkpoint(local_model_path)
     return local_model_path
 
+
 def fix_bad_tokenizer(checkpoint_dir: str):
     path = os.path.join(checkpoint_dir, "config.yaml")
     conf = om.load(path)
     conf["tokenizer"]["identifier"] = "allenai/gpt-neox-olmo-dolma-v1_5"
     conf["model"]["eos_token_id"] = 50279
     om.save(conf, path)
+
 
 def main():
     parser = argparse.ArgumentParser(

--- a/hf_olmo/convert_olmo_to_hf.py
+++ b/hf_olmo/convert_olmo_to_hf.py
@@ -90,6 +90,12 @@ def download_remote_checkpoint_and_convert_to_hf(checkpoint_dir: str, local_dir:
     convert_checkpoint(local_model_path)
     return local_model_path
 
+def fix_bad_tokenizer(checkpoint_dir: str):
+    path = os.path.join(checkpoint_dir, "config.yaml")
+    conf = om.load(path)
+    conf["tokenizer"]["identifier"] = "allenai/gpt-neox-olmo-dolma-v1_5"
+    conf["model"]["eos_token_id"] = 50279
+    om.save(conf, path)
 
 def main():
     parser = argparse.ArgumentParser(
@@ -109,6 +115,7 @@ def main():
     )
 
     args = parser.parse_args()
+    fix_bad_tokenizer(args.checkpoint_dir)
     convert_checkpoint(args.checkpoint_dir, args.ignore_olmo_compatibility)
 
 

--- a/hf_olmo/convert_olmo_to_hf.py
+++ b/hf_olmo/convert_olmo_to_hf.py
@@ -5,6 +5,7 @@ import shutil
 
 import torch
 from omegaconf import OmegaConf as om
+
 from hf_olmo.configuration_olmo import OLMoConfig
 from hf_olmo.modeling_olmo import OLMoForCausalLM
 from hf_olmo.tokenization_olmo_fast import OLMoTokenizerFast

--- a/hf_olmo/convert_olmo_to_hf.py
+++ b/hf_olmo/convert_olmo_to_hf.py
@@ -4,7 +4,7 @@ import os
 import shutil
 
 import torch
-
+from omegaconf import OmegaConf as om
 from hf_olmo.configuration_olmo import OLMoConfig
 from hf_olmo.modeling_olmo import OLMoForCausalLM
 from hf_olmo.tokenization_olmo_fast import OLMoTokenizerFast


### PR DESCRIPTION
If you just want to fix the tokenizer files, without running the full conversion:

```python
fix_bad_tokenizer(path)  # assumes native olmo compatibility, i.e., ensure that the original config.yaml is present
write_tokenizer(path)
```