### PR TITLE
Add cfg option `--scheduler.warmup_min_lr`

### DIFF
--- a/olmo/config.py
+++ b/olmo/config.py
@@ -531,6 +531,12 @@ class SchedulerConfig(BaseConfig):
     vs after the warmup period.
     """
 
+    warmup_min_lr: Optional[float] = None
+    """
+    The starting LR during the warmup period. If not set this defaults to 10% of
+    the target LR.
+    """
+
 
 class PaddingDirection(StrEnum):
     right = "right"

--- a/olmo/optim.py
+++ b/olmo/optim.py
@@ -560,6 +560,7 @@ class BoltOnWarmupScheduler(Scheduler):
             inner=scheduler,
             warmup_start=warmup_start,
             warmup_end=warmup_end,
+            warmup_min_lr=None,
         )
 
     def get_lr(self, initial_lr: float, step: int, max_steps: int) -> float:

--- a/olmo/optim.py
+++ b/olmo/optim.py
@@ -449,6 +449,7 @@ class Scheduler(metaclass=ABCMeta):
     # about how the scheduler subclasses are defined.
     grad_clip_warmup_steps: Optional[int]
     grad_clip_warmup_factor: Optional[float]
+    warmup_min_lr: Optional[float]
 
     @abstractmethod
     def get_lr(self, initial_lr: float, step: int, max_steps: int) -> float:
@@ -480,7 +481,11 @@ class Scheduler(metaclass=ABCMeta):
         return self._get_max_grad_norm_coeff(initial_max_grad_norm_ratio, step, max_steps)
 
     def _linear_warmup(self, initial_lr: float, step: int, warmup_steps: int = 2000) -> float:
-        return initial_lr * (0.1 + 0.9 * min(step, warmup_steps) / warmup_steps)
+        if self.warmup_min_lr is not None:
+            assert initial_lr > self.warmup_min_lr
+            return self.warmup_min_lr + (initial_lr - self.warmup_min_lr) * min(step, warmup_steps) / warmup_steps
+        else:
+            return initial_lr * (0.1 + 0.9 * min(step, warmup_steps) / warmup_steps)
 
 
 @dataclass
@@ -730,6 +735,7 @@ def build_scheduler(cfg: TrainConfig, sched_cfg: Optional[SchedulerConfig] = Non
             warmup_steps=int(sched_cfg.t_warmup),
             alpha_f=sched_cfg.alpha_f,
             t_max=None if sched_cfg.t_max is None else int(sched_cfg.t_max),
+            warmup_min_lr=sched_cfg.warmup_min_lr,
         )
     elif sched_cfg.name == SchedulerType.linear_with_warmup:
         return LinearWithWarmup(
@@ -740,6 +746,7 @@ def build_scheduler(cfg: TrainConfig, sched_cfg: Optional[SchedulerConfig] = Non
             warmup_steps=int(sched_cfg.t_warmup),
             alpha_f=sched_cfg.alpha_f,
             t_max=None if sched_cfg.t_max is None else int(sched_cfg.t_max),
+            warmup_min_lr=sched_cfg.warmup_min_lr,
         )
     elif sched_cfg.name == SchedulerType.inverse_sqrt_with_warmup:
         return InvSqrtWithWarmup(
@@ -748,6 +755,7 @@ def build_scheduler(cfg: TrainConfig, sched_cfg: Optional[SchedulerConfig] = Non
             else int(sched_cfg.grad_clip_warmup_steps),
             grad_clip_warmup_factor=sched_cfg.grad_clip_warmup_factor,
             warmup_steps=int(sched_cfg.t_warmup),
+            warmup_min_lr=sched_cfg.warmup_min_lr,
         )
     elif sched_cfg.name == SchedulerType.max_scheduler:
         return MaxScheduler(
@@ -757,6 +765,7 @@ def build_scheduler(cfg: TrainConfig, sched_cfg: Optional[SchedulerConfig] = Non
             grad_clip_warmup_factor=sched_cfg.grad_clip_warmup_factor,
             sched1=build_scheduler(cfg, replace(sched_cfg, name=SchedulerType.cosine_with_warmup)),
             sched2=build_scheduler(cfg, replace(sched_cfg, name=SchedulerType.inverse_sqrt_with_warmup)),
+            warmup_min_lr=sched_cfg.warmup_min_lr,
         )
     elif sched_cfg.name == SchedulerType.constant:
         return ConstantScheduler(
@@ -764,6 +773,7 @@ def build_scheduler(cfg: TrainConfig, sched_cfg: Optional[SchedulerConfig] = Non
             if sched_cfg.grad_clip_warmup_steps is None
             else int(sched_cfg.grad_clip_warmup_steps),
             grad_clip_warmup_factor=sched_cfg.grad_clip_warmup_factor,
+            warmup_min_lr=sched_cfg.warmup_min_lr,
         )
     else:
         raise NotImplementedError

--- a/olmo/optim.py
+++ b/olmo/optim.py
@@ -481,11 +481,9 @@ class Scheduler(metaclass=ABCMeta):
         return self._get_max_grad_norm_coeff(initial_max_grad_norm_ratio, step, max_steps)
 
     def _linear_warmup(self, initial_lr: float, step: int, warmup_steps: int = 2000) -> float:
-        if self.warmup_min_lr is not None:
-            assert initial_lr > self.warmup_min_lr
-            return self.warmup_min_lr + (initial_lr - self.warmup_min_lr) * min(step, warmup_steps) / warmup_steps
-        else:
-            return initial_lr * (0.1 + 0.9 * min(step, warmup_steps) / warmup_steps)
+        warmup_min_lr = self.warmup_min_lr if self.warmup_min_lr is not None else initial_lr * 0.10
+        assert 0 <= warmup_min_lr < initial_lr
+        return warmup_min_lr + (initial_lr - warmup_min_lr) * min(step, warmup_steps) / warmup_steps
 
 
 @dataclass

--- a/tests/optim_test.py
+++ b/tests/optim_test.py
@@ -6,7 +6,9 @@ from olmo.optim import BoltOnWarmupScheduler, LinearWithWarmup
 def test_linear_with_warmup_scheduler():
     initial_lr = 1.0
     max_steps = 10_000
-    scheduler = LinearWithWarmup(grad_clip_warmup_steps=None, grad_clip_warmup_factor=None, warmup_steps=2000)
+    scheduler = LinearWithWarmup(
+        grad_clip_warmup_steps=None, grad_clip_warmup_factor=None, warmup_steps=2000, warmup_min_lr=None
+    )
     assert scheduler.get_lr(initial_lr, 0, max_steps) == 0.1
     assert scheduler.get_lr(initial_lr, 2000, max_steps) == 1.0
     assert scheduler.get_lr(initial_lr, 10_000, max_steps) == 0.1
@@ -18,7 +20,11 @@ def test_bolt_on_warmup_scheduler():
     max_steps = 11_000
     alpha_f = 0.1
     scheduler = LinearWithWarmup(
-        grad_clip_warmup_steps=None, grad_clip_warmup_factor=None, warmup_steps=1000, alpha_f=alpha_f
+        grad_clip_warmup_steps=None,
+        grad_clip_warmup_factor=None,
+        warmup_steps=1000,
+        alpha_f=alpha_f,
+        warmup_min_lr=None,
     )
     scheduler2 = BoltOnWarmupScheduler.wrap(scheduler, 5000, 6000)
     assert scheduler.get_lr(initial_lr, 100, max_steps) > 0.0


### PR DESCRIPTION
For setting the starting LR during the warmup period. When no set this defaults to the current behavior of starting at 10% of the target LR.