### PR TITLE
Add checkpoint csv for OLMo 1.7

### DIFF
--- a/checkpoints/official/OLMo-1.7-7B.csv
+++ b/checkpoints/official/OLMo-1.7-7B.csv
@@ -1,0 +1,3 @@
+Step,Checkpoint Directory
+477000,https://olmo-checkpoints.org/ai2-llm/olmo-medium/0rdfxd6d/step477000-unsharded/
+489000,https://olmo-checkpoints.org/ai2-llm/olmo-annealing/yu3ctnnk/step12000-unsharded/


### PR DESCRIPTION
This contains the URLs to OLMo 1.7 checkpoints. Refer to the README for instructions on how to use these URLs.