### PR TITLE
Add Weka storage support

### DIFF
--- a/olmo/checkpoint.py
+++ b/olmo/checkpoint.py
@@ -375,6 +375,8 @@ class RemoteFileSystemWriter(dist_cp.FileSystemWriter):
                 _get_s3_client("s3")
             elif self.upload_to.startswith("r2://"):
                 _get_s3_client("r2")
+            elif self.upload_to.startswith("weka://"):
+                _get_s3_client("weka")
 
             with ThreadPoolExecutor(max_workers=self.thread_count) as executor:
                 futures = []
@@ -438,6 +440,8 @@ class RemoteFileSystemReader(dist_cp.StorageReader):
                 _get_s3_client("s3")
             elif self.path.startswith("r2://"):
                 _get_s3_client("r2")
+            elif self.path.startswith("weka://"):
+                _get_s3_client("weka")
 
         with ThreadPoolExecutor(max_workers=self.thread_count) as executor:
             read_item_content_futures = []

--- a/olmo/data/memmap_dataset.py
+++ b/olmo/data/memmap_dataset.py
@@ -101,6 +101,12 @@ class MemMapDataset(Dataset[Dict[str, Any]]):
             # R2 might not be needed, so ignore this error. We will get an error
             # later if R2 is needed.
             pass
+        try:
+            _get_s3_client("weka")
+        except OLMoEnvironmentError:
+            # Weka might not be needed, so ignore this error. We will get an error
+            # later if Weka is needed.
+            pass
 
         if self._mmap_offsets is None:
             import concurrent.futures

--- a/olmo/util.py
+++ b/olmo/util.py
@@ -644,9 +644,7 @@ def _http_get_bytes_range(scheme: str, host_name: str, path: str, bytes_start: i
     result = response.content
     assert (
         len(result) == num_bytes
-    ), (
-        f"expected {num_bytes} bytes, got {len(result)}"
-    )  # Some web servers silently ignore range requests and send everything
+    ), f"expected {num_bytes} bytes, got {len(result)}"  # Some web servers silently ignore range requests and send everything
     return result
 
 

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -31,7 +31,12 @@ from olmo.torch_util import (
     seed_all,
 )
 from olmo.train import Trainer
-from olmo.util import add_cached_path_clients, clean_opt, log_extra_field, prepare_cli_environment
+from olmo.util import (
+    add_cached_path_clients,
+    clean_opt,
+    log_extra_field,
+    prepare_cli_environment,
+)
 
 log = logging.getLogger("train")
 

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -31,7 +31,7 @@ from olmo.torch_util import (
     seed_all,
 )
 from olmo.train import Trainer
-from olmo.util import clean_opt, log_extra_field, prepare_cli_environment
+from olmo.util import add_cached_path_clients, clean_opt, log_extra_field, prepare_cli_environment
 
 log = logging.getLogger("train")
 
@@ -284,6 +284,8 @@ if __name__ == "__main__":
 
     prepare_cli_environment()
     log.info("CLI environment prepared")
+
+    add_cached_path_clients()
 
     try:
         yaml_path, args_list = sys.argv[1], sys.argv[2:]


### PR DESCRIPTION
Adds support for Weka storage, which is the primary storage in the Jupiter cluster. It might eventually be added a file system, but for now it is exposed as an S3 endpoint. The main changes are:

- Add Weka for `_get_s3_client`, where it is basically treated identically to R2.
- Add a Weka scheme client for `cached_path`. It didn't seem right to put this in `cached_path` since Weka is not a common/universal storage system. 