### PR TITLE
Remove usages of Auto* methods in hf_olmo tests

### DIFF
--- a/tests/hf_olmo/configuration_olmo_test.py
+++ b/tests/hf_olmo/configuration_olmo_test.py
@@ -1,16 +1,18 @@
 from olmo.config import ModelConfig
+import tempfile
 
 
 def test_config_save(model_path: str):
     from hf_olmo.configuration_olmo import OLMoConfig
 
-    config = ModelConfig(alibi=True)  # default is False
-    hf_config = OLMoConfig(**config.asdict())
+    with tempfile.TemporaryDirectory() as temp_dir:
+        config = ModelConfig(alibi=True)  # default is False
+        hf_config = OLMoConfig(**config.asdict())
 
-    hf_config.save_pretrained(model_path)
-    loaded_hf_config = OLMoConfig.from_pretrained(model_path)
+        hf_config.save_pretrained(temp_dir)
+        loaded_hf_config = OLMoConfig.from_pretrained(temp_dir)
 
-    assert hf_config.to_dict() == loaded_hf_config.to_dict()
+        assert hf_config.to_dict() == loaded_hf_config.to_dict()
 
-    for key, val in config.asdict().items():
-        assert getattr(loaded_hf_config, key) == val
+        for key, val in config.asdict().items():
+            assert getattr(loaded_hf_config, key) == val

--- a/tests/hf_olmo/configuration_olmo_test.py
+++ b/tests/hf_olmo/configuration_olmo_test.py
@@ -1,5 +1,6 @@
-from olmo.config import ModelConfig
 import tempfile
+
+from olmo.config import ModelConfig
 
 
 def test_config_save(model_path: str):

--- a/tests/hf_olmo/hf_pipeline_test.py
+++ b/tests/hf_olmo/hf_pipeline_test.py
@@ -1,11 +1,10 @@
 def test_pipeline(model_path: str):
     from transformers import TextGenerationPipeline
-    from transformers.models.auto import AutoModelForCausalLM, AutoTokenizer
 
-    from hf_olmo.modeling_olmo import OLMoConfig, OLMoForCausalLM  # noqa: F401
+    from hf_olmo import OLMoForCausalLM, OLMoTokenizerFast
 
-    model = AutoModelForCausalLM.from_pretrained(model_path)
-    tokenizer = AutoTokenizer.from_pretrained(model_path)
+    model = OLMoForCausalLM.from_pretrained(model_path)
+    tokenizer = OLMoTokenizerFast.from_pretrained(model_path)
     pipeline = TextGenerationPipeline(model=model, tokenizer=tokenizer)
     output = pipeline("question: who wrote romeo and juliet? answer: ", max_new_tokens=30)
     assert "generated_text" in output[0]

--- a/tests/hf_olmo/modeling_olmo_test.py
+++ b/tests/hf_olmo/modeling_olmo_test.py
@@ -3,18 +3,15 @@ import tempfile
 import pytest
 import torch
 
+from hf_olmo import OLMoForCausalLM, OLMoTokenizerFast
 from olmo.model import OLMo
 
 
 def test_olmo_model(model_path: str):
-    from transformers import AutoModelForCausalLM, AutoTokenizer
-
-    from hf_olmo import OLMoForCausalLM, OLMoTokenizerFast  # noqa: F401
-
     model = OLMo.from_checkpoint(model_path)
-    hf_model = AutoModelForCausalLM.from_pretrained(model_path)
+    hf_model = OLMoForCausalLM.from_pretrained(model_path)
 
-    tokenizer = AutoTokenizer.from_pretrained(model_path)
+    tokenizer = OLMoTokenizerFast.from_pretrained(model_path)
     input = tokenizer.encode("My name is OLMo!")
     input_tensor = torch.tensor(input).unsqueeze(0)
 
@@ -25,21 +22,17 @@ def test_olmo_model(model_path: str):
 
 
 def test_save_pretrained(model_path: str):
-    from transformers import AutoModelForCausalLM, AutoTokenizer
-
-    from hf_olmo import OLMoForCausalLM, OLMoTokenizerFast  # noqa: F401
-
-    tokenizer = AutoTokenizer.from_pretrained(model_path)
+    tokenizer = OLMoTokenizerFast.from_pretrained(model_path)
     input = tokenizer.encode("My name is OLMo!")
     input_tensor = torch.tensor(input).unsqueeze(0)
 
-    hf_model = AutoModelForCausalLM.from_pretrained(model_path)
+    hf_model = OLMoForCausalLM.from_pretrained(model_path)
     hf_output = hf_model(input_tensor)
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         hf_model.save_pretrained(tmp_dir)
 
-        saved_hf_model = AutoModelForCausalLM.from_pretrained(tmp_dir)
+        saved_hf_model = OLMoForCausalLM.from_pretrained(tmp_dir)
         saved_hf_output = saved_hf_model(input_tensor)
 
         torch.testing.assert_allclose(saved_hf_output.logits, hf_output.logits)
@@ -48,9 +41,5 @@ def test_save_pretrained(model_path: str):
 @pytest.mark.gpu
 @pytest.mark.skipif(torch.cuda.device_count() < 1, reason="Requires CUDA devices")
 def test_auto_device_map_load(model_path: str):
-    from transformers import AutoModelForCausalLM
-
-    from hf_olmo import OLMoForCausalLM, OLMoTokenizerFast  # noqa: F401
-
-    hf_model = AutoModelForCausalLM.from_pretrained(model_path, device_map="auto")
+    hf_model = OLMoForCausalLM.from_pretrained(model_path, device_map="auto")
     assert hf_model.device.type == "cuda"

--- a/tests/hf_olmo/tokenization_olmo_fast_test.py
+++ b/tests/hf_olmo/tokenization_olmo_fast_test.py
@@ -1,15 +1,12 @@
 import tempfile
 
+from hf_olmo import OLMoTokenizerFast
 from olmo.tokenizer import Tokenizer
 
 
 def test_olmo_tokenizer(model_path: str):
-    from transformers import AutoTokenizer
-
-    from hf_olmo import OLMoTokenizerFast  # noqa: F401
-
     tok = Tokenizer.from_checkpoint(model_path)
-    hf_tok = AutoTokenizer.from_pretrained(model_path)
+    hf_tok = OLMoTokenizerFast.from_pretrained(model_path)
 
     input_str = "Hello, this is a test!"
 
@@ -26,11 +23,7 @@ def test_olmo_tokenizer(model_path: str):
 
 
 def test_save_pretrained(model_path: str):
-    from transformers import AutoTokenizer
-
-    from hf_olmo import OLMoTokenizerFast  # noqa: F401
-
-    hf_tok = AutoTokenizer.from_pretrained(model_path)
+    hf_tok = OLMoTokenizerFast.from_pretrained(model_path)
 
     input_str = "Hello, this is a test!"
 
@@ -40,7 +33,7 @@ def test_save_pretrained(model_path: str):
     with tempfile.TemporaryDirectory() as tmp_dir:
         hf_tok.save_pretrained(tmp_dir)
 
-        saved_hf_tok = AutoTokenizer.from_pretrained(tmp_dir)
+        saved_hf_tok = OLMoTokenizerFast.from_pretrained(tmp_dir)
         saved_hf_tokenized = saved_hf_tok.encode(input_str)
 
         assert hf_tokenized == saved_hf_tokenized


### PR DESCRIPTION
Using `Auto*` methods is not supported for `hf_olmo` for transformers `>=4.40.0`. More details in https://github.com/allenai/OLMo/blob/main/docs/Checkpoints.md. This PR removes the usage of `Auto*` methods for accessing the `hf_olmo` implementation in our tests.