### PR TITLE
Unshard without passing checkpointer type

### DIFF
--- a/olmo/checkpoint.py
+++ b/olmo/checkpoint.py
@@ -1914,13 +1914,13 @@ class OlmoCoreCheckpointer(Checkpointer):
 
 
 def build_sharded_checkpointer(
-    cfg: TrainConfig, *, name: Optional[ShardedCheckpointerType] = None
+    cfg: TrainConfig, *, name: Optional[ShardedCheckpointerType] = None, use_shared_mem_impl: bool = False
 ) -> Checkpointer:
     name = name or cfg.sharded_checkpointer
     if name == ShardedCheckpointerType.torch_new:
         return TorchNewStyleShardedCheckpointer(cfg)
     elif name == ShardedCheckpointerType.torch_legacy:
-        return TorchLegacyShardedCheckpointer(cfg)
+        return TorchLegacyShardedCheckpointer(cfg, use_shared_mem_impl=use_shared_mem_impl)
     elif name == ShardedCheckpointerType.local:
         return LocalShardedCheckpointer(cfg)
     elif name == ShardedCheckpointerType.olmo_core:

--- a/olmo/checkpoint.py
+++ b/olmo/checkpoint.py
@@ -542,7 +542,6 @@ class Checkpointer(metaclass=ABCMeta):
 
         Note this is not marked abstract because child classes are not required to implemented this.
         """
-        del load_path, local_cache, load_optimizer_state, load_trainer_state, device
         raise NotImplementedError
 
     @contextmanager

--- a/scripts/unshard.py
+++ b/scripts/unshard.py
@@ -1,7 +1,7 @@
 import logging
 import shutil
 from pathlib import Path
-from typing import Union
+from typing import Optional, Union
 
 import torch
 
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 def main(
     input_dir: Union[str, Path],
     output_dir: Union[str, Path],
-    sharded_checkpoint_type: ShardedCheckpointerType = ShardedCheckpointerType.torch_legacy,
+    sharded_checkpoint_type: Optional[ShardedCheckpointerType] = None,
     model_only: bool = False,
     safe_tensors: bool = False,
     use_shared_mem_impl: bool = False,
@@ -27,6 +27,8 @@ def main(
     output_dir.mkdir(parents=True, exist_ok=True)
 
     config = TrainConfig.load(input_dir / "config.yaml", validate_paths=False)
+
+    sharded_checkpoint_type = sharded_checkpoint_type or config.sharded_checkpointer
     checkpointer = build_sharded_checkpointer(
         config, name=sharded_checkpoint_type, use_shared_mem_impl=use_shared_mem_impl
     )
@@ -81,8 +83,8 @@ if __name__ == "__main__":
     parser.add_argument(
         "--type",
         choices=list(ShardedCheckpointerType),
-        default=ShardedCheckpointerType.torch_legacy,
-        help="""The sharded checkpoint type.""",
+        default=None,
+        help="""The sharded checkpoint type. Defaults to the sharded checkpoint type set in config.""",
     )
     parser.add_argument(
         "--model-only",


### PR DESCRIPTION
The unsharding script currently requires us to pass in the checkpoint type, but this is not necessary since it can be read from config. Passing in the type has been a nuisance in the past, so this PR changes the script to default to the checkpoint type in the config. It changes the unsharder to use `build_sharded_checkpointer`, so that we don't need to duplicate that logic in the unsharding script.

Currently untested.