### PR TITLE
Rewrite initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added original legacy unsharding implementation back, as the default. The new
 shared memory implementation can be used by passing `use_legacy_shared_mem_impl` to `unshard.py`.
-- Refactor weight initialization. IMPORTANT: this does not maintain backwards-compatibility with older configs; the jobs will still run, but may produce different outputs.
+- Refactor weight initialization. IMPORTANT: this does not maintain backwards-compatibility with older configs; the jobs will still run, but may produce different outputs. Also, `scale_logits` is deprecated.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added original legacy unsharding implementation back, as the default. The new
 shared memory implementation can be used by passing `use_legacy_shared_mem_impl` to `unshard.py`.
-- Refactor weight initialization. IMPORTANT: this does not maintain backwards-compatibility with older configs; the jobs will still run, but may produce different outputs. Also, `scale_logits` is deprecated.
+- Refactor weight initialization. IMPORTANT: this does not maintain backwards-compatibility with older configs; the jobs will still run, but may produce different outputs.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added original legacy unsharding implementation back, as the default. The new
 shared memory implementation can be used by passing `use_legacy_shared_mem_impl` to `unshard.py`.
-- Refactor weight initialization.
+- Refactor weight initialization. IMPORTANT: this does not maintain backwards-compatibility with older configs; the jobs will still run, but may produce different outputs.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added original legacy unsharding implementation back, as the default. The new
 shared memory implementation can be used by passing `use_legacy_shared_mem_impl` to `unshard.py`.
+- Refactor weight initialization.
 
 ### Fixed
 

--- a/olmo/config.py
+++ b/olmo/config.py
@@ -376,7 +376,7 @@ class ModelConfig(BaseConfig):
 
     scale_logits: bool = False
     """
-    Deprecated. This is no longer supported.
+    If ``True``, scale the output logits by ``1 / sqrt(d_model)``.
     """
 
     vocab_size: int = 50257

--- a/olmo/config.py
+++ b/olmo/config.py
@@ -376,7 +376,7 @@ class ModelConfig(BaseConfig):
 
     scale_logits: bool = False
     """
-    If ``True``, scale the output logits by ``1 / sqrt(d_model)``.
+    Deprecated. This is no longer supported.
     """
 
     vocab_size: int = 50257

--- a/olmo/initialization.py
+++ b/olmo/initialization.py
@@ -17,6 +17,24 @@ class ModuleType(StrEnum):
     final_out = "final_out"
 
 
+def init_normal(
+    config: ModelConfig,
+    module: Union[nn.Linear, nn.Embedding],
+    std_factor: float = 1.00,
+):
+    std = config.init_std * std_factor
+
+    # weights
+    if config.init_cutoff_factor is not None:
+        cutoff_value = config.init_cutoff_factor * std
+        nn.init.trunc_normal_(module.weight, mean=0.0, std=std, a=-cutoff_value, b=cutoff_value)
+    else:
+        nn.init.normal_(module.weight, mean=0.0, std=std)
+
+    # biases
+    if isinstance(module, nn.Linear) and module.bias is not None:
+        nn.init.zeros_(module.bias)
+
 def init_weights(
     config: ModelConfig,
     module: Union[nn.Linear, nn.Embedding],

--- a/olmo/initialization.py
+++ b/olmo/initialization.py
@@ -35,6 +35,28 @@ def init_normal(
     if isinstance(module, nn.Linear) and module.bias is not None:
         nn.init.zeros_(module.bias)
 
+def init_mitchell(
+    config: ModelConfig,
+    module: Union[nn.Linear, nn.Embedding],
+    layer_id: Optional[int] = None,
+    std_factor: float = 1.00,
+    d: Optional[int] = None,
+):
+    # TODO: potentially roll into init_normal
+    # weights
+    d = d if d is not None else config.d_model
+    # std = 1/(math.sqrt(2*d*(layer_id+1))
+    std = std_factor / math.sqrt(d)
+    if layer_id is not None:
+        std = std / math.sqrt(2 * (layer_id + 1))
+
+    # TODO: 3 is currently hardcoded; this should be using init_cutoff_factor instead.
+    nn.init.trunc_normal_(module.weight, mean=0.0, std=std, a=-3 * std, b=3 * std)
+
+    # biases
+    if isinstance(module, nn.Linear) and module.bias is not None:
+        nn.init.zeros_(module.bias)
+
 def init_weights(
     config: ModelConfig,
     module: Union[nn.Linear, nn.Embedding],

--- a/olmo/initialization.py
+++ b/olmo/initialization.py
@@ -18,15 +18,13 @@ class ModuleType(StrEnum):
 
 
 def init_normal(
-    config: ModelConfig,
     module: Union[nn.Linear, nn.Embedding],
-    std_factor: float = 1.00,
+    std: float,
+    init_cutoff_factor: Optional[float] = None,
 ):
-    std = config.init_std * std_factor
-
     # weights
-    if config.init_cutoff_factor is not None:
-        cutoff_value = config.init_cutoff_factor * std
+    if init_cutoff_factor is not None:
+        cutoff_value = init_cutoff_factor * std
         nn.init.trunc_normal_(module.weight, mean=0.0, std=std, a=-cutoff_value, b=cutoff_value)
     else:
         nn.init.normal_(module.weight, mean=0.0, std=std)
@@ -35,27 +33,6 @@ def init_normal(
     if isinstance(module, nn.Linear) and module.bias is not None:
         nn.init.zeros_(module.bias)
 
-def init_mitchell(
-    config: ModelConfig,
-    module: Union[nn.Linear, nn.Embedding],
-    layer_id: Optional[int] = None,
-    std_factor: float = 1.00,
-    d: Optional[int] = None,
-):
-    # TODO: potentially roll into init_normal
-    # weights
-    d = d if d is not None else config.d_model
-    # std = 1/(math.sqrt(2*d*(layer_id+1))
-    std = std_factor / math.sqrt(d)
-    if layer_id is not None:
-        std = std / math.sqrt(2 * (layer_id + 1))
-
-    # TODO: 3 is currently hardcoded; this should be using init_cutoff_factor instead.
-    nn.init.trunc_normal_(module.weight, mean=0.0, std=std, a=-3 * std, b=3 * std)
-
-    # biases
-    if isinstance(module, nn.Linear) and module.bias is not None:
-        nn.init.zeros_(module.bias)
 
 def init_weights(
     config: ModelConfig,

--- a/olmo/initialization.py
+++ b/olmo/initialization.py
@@ -1,20 +1,8 @@
-import math
 from typing import Optional, Union
 
-import torch
 import torch.nn as nn
 
-from .config import InitFnType, ModelConfig
-from .util import StrEnum
-
-__all__ = ["init_weights", "ModuleType"]
-
-
-class ModuleType(StrEnum):
-    in_module = "in"
-    out_module = "out"
-    emb = "emb"
-    final_out = "final_out"
+__all__ = ["init_normal"]
 
 
 def init_normal(
@@ -32,81 +20,3 @@ def init_normal(
     # biases
     if isinstance(module, nn.Linear) and module.bias is not None:
         nn.init.zeros_(module.bias)
-
-
-def init_weights(
-    config: ModelConfig,
-    module: Union[nn.Linear, nn.Embedding],
-    d: Optional[int] = None,
-    layer_id: Optional[int] = None,
-    std_factor: float = 1.0,
-    type_of_module: Optional[ModuleType] = None,
-) -> None:
-    """
-    Initialize weights of a linear or embedding module.
-
-    :param config: The model config.
-    :param module: The linear or embedding submodule to initialize.
-    :param d: The effective input dimensionality of the weights. This could be smaller than the actual dimensions
-        for fused layers.
-    :param layer_id: When set, the standard deviation for the "mitchell" method will be adjusted by
-        ``1 / sqrt(2 * (layer_id + 1))``.
-    """
-    d = d if d is not None else config.d_model
-    if config.init_fn == InitFnType.normal:
-        std = config.init_std * std_factor
-        if config.init_cutoff_factor is not None:
-            cutoff_value = config.init_cutoff_factor * std
-            nn.init.trunc_normal_(module.weight, mean=0.0, std=std, a=-cutoff_value, b=cutoff_value)
-        else:
-            nn.init.normal_(module.weight, mean=0.0, std=std)
-    elif config.init_fn == InitFnType.mitchell:
-        std = std_factor / math.sqrt(d)
-        if layer_id is not None:
-            std = std / math.sqrt(2 * (layer_id + 1))
-        nn.init.trunc_normal_(module.weight, mean=0.0, std=std, a=-3 * std, b=3 * std)
-    elif config.init_fn == InitFnType.kaiming_normal:
-        nn.init.kaiming_normal_(module.weight, nonlinearity="relu")
-    elif config.init_fn == InitFnType.fan_in:
-        std = std_factor / math.sqrt(d)
-        nn.init.normal_(module.weight, mean=0.0, std=std)
-    elif config.init_fn == InitFnType.full_megatron:
-        if type_of_module is None:
-            raise RuntimeError(f"When using the {InitFnType.full_megatron} init, every module must have a type.")
-
-        cutoff_factor = config.init_cutoff_factor
-        if cutoff_factor is None:
-            cutoff_factor = 3
-
-        if type_of_module == ModuleType.in_module:
-            # for att_proj (same as QKV), ff_proj
-            std = config.init_std
-        elif type_of_module == ModuleType.out_module:
-            # for attn_out, ff_out
-            std = config.init_std / math.sqrt(2.0 * config.n_layers)
-        elif type_of_module == ModuleType.emb:
-            # positional embeddings (wpe)
-            # token embeddings (wte)
-            std = config.init_std
-        elif type_of_module == ModuleType.final_out:
-            # final output (ff_out)
-            std = config.d_model**-0.5
-        else:
-            raise RuntimeError(f"Unknown module type '{type_of_module}'")
-        nn.init.trunc_normal_(
-            module.weight,
-            mean=0.0,
-            std=std,
-            a=-cutoff_factor * std,
-            b=cutoff_factor * std,
-        )
-    else:
-        raise NotImplementedError(config.init_fn)
-
-    if isinstance(module, nn.Linear):
-        if module.bias is not None:
-            nn.init.zeros_(module.bias)
-
-        if config.init_fn == InitFnType.normal and getattr(module, "_is_residual", False):
-            with torch.no_grad():
-                module.weight.div_(math.sqrt(2 * config.n_layers))

--- a/olmo/model.py
+++ b/olmo/model.py
@@ -480,13 +480,11 @@ class OLMoBlock(nn.Module):
             cutoff_factor = self.config.init_cutoff_factor
 
         elif self.config.init_fn == InitFnType.mitchell:
-            # TODO: 3 is currently hardcoded; this should be using init_cutoff_factor instead.
             attn_out_std = 1 / (math.sqrt(2 * self.config.d_model * (self.layer_id + 1)))
             ff_out_std = 1 / (math.sqrt(2 * self.ff_out.in_features * (self.layer_id + 1)))
-            cutoff_factor = 3.0
+            cutoff_factor = self.config.init_cutoff_factor or 3.0
 
         elif self.config.init_fn == InitFnType.full_megatron:
-            # TODO: 3 is hardcoded as default value
             attn_out_std = ff_out_std = self.config.init_std / math.sqrt(2.0 * self.config.n_layers)
             cutoff_factor = self.config.init_cutoff_factor or 3.0
 
@@ -676,7 +674,7 @@ class OLMoSequentialBlock(OLMoBlock):
             cutoff_factor = self.config.init_cutoff_factor
         elif self.config.init_fn == InitFnType.mitchell:
             std = 1 / math.sqrt(self.config.d_model)
-            cutoff_factor = 3.0
+            cutoff_factor = self.config.init_cutoff_factor or 3.0
         elif self.config.init_fn == InitFnType.full_megatron:
             std = self.config.init_std
             cutoff_factor = self.config.init_cutoff_factor or 3.0
@@ -791,7 +789,7 @@ class OLMoLlamaBlock(OLMoBlock):
             cutoff_factor = self.config.init_cutoff_factor
         elif self.config.init_fn == InitFnType.mitchell:
             std = 1 / math.sqrt(self.config.d_model)
-            cutoff_factor = 3.0
+            cutoff_factor = self.config.init_cutoff_factor or 3.0
         elif self.config.init_fn == InitFnType.full_megatron:
             std = self.config.init_std
             cutoff_factor = self.config.init_cutoff_factor or 3.0
@@ -1059,7 +1057,7 @@ class OLMo(nn.Module):
         elif self.config.init_fn == InitFnType.mitchell:
             # TODO: this is buggy! std will always be 0.5 when scale_logits = True
             wte_std = emb_std_factor / math.sqrt(self.config.d_model)
-            wte_cutoff_factor = 3.0
+            wte_cutoff_factor = self.config.init_cutoff_factor or 3.0
         elif self.config.init_fn == InitFnType.full_megatron:
             wte_std = self.config.init_std
             wte_cutoff_factor = self.config.init_cutoff_factor or 3.0
@@ -1074,7 +1072,7 @@ class OLMo(nn.Module):
                 wpe_cutoff_factor = self.config.init_cutoff_factor
             elif self.config.init_fn == InitFnType.mitchell:
                 wpe_std = 1 / math.sqrt(self.config.d_model)
-                wpe_cutoff_factor = 3.0
+                wpe_cutoff_factor = self.config.init_cutoff_factor or 3.0
             elif self.config.init_fn == InitFnType.full_megatron:
                 wpe_std = self.config.init_std
                 wpe_cutoff_factor = self.config.init_cutoff_factor or 3.0
@@ -1093,7 +1091,7 @@ class OLMo(nn.Module):
                 ff_out_cutoff_factor = self.config.init_cutoff_factor
             elif self.config.init_fn == InitFnType.mitchell:
                 ff_out_std = 1 / math.sqrt(self.config.d_model)
-                ff_out_cutoff_factor = 3.0
+                ff_out_cutoff_factor = self.config.init_cutoff_factor or 3.0
             elif self.config.init_fn == InitFnType.full_megatron:
                 ff_out_std = 1 / math.sqrt(self.config.d_model)
                 ff_out_cutoff_factor = self.config.init_cutoff_factor or 3.0

--- a/olmo/model.py
+++ b/olmo/model.py
@@ -41,6 +41,7 @@ from .config import (
     FSDPWrapStrategy,
     LayerNormType,
     ModelConfig,
+    InitFnType,
 )
 from .exceptions import OLMoConfigurationError
 from .initialization import ModuleType, init_weights, init_normal
@@ -475,7 +476,7 @@ class OLMoBlock(nn.Module):
             self.q_norm.reset_parameters()
 
         # TOD0: move step by step
-        if self.config.init_fn == "normal":
+        if self.config.init_fn == InitFnType.normal:
             init_normal(self.config, self.attn_out)
             init_normal(self.config, self.ff_out)
 
@@ -678,24 +679,9 @@ class OLMoSequentialBlock(OLMoBlock):
         self.ff_norm.reset_parameters()
         # NOTE: the standard deviation for these weights does not depend on the layer.
 
-        if self.config.init_fn == "normal":
+        if self.config.init_fn == InitFnType.normal:
             init_normal(self.config, self.att_proj)
             init_normal(self.config, self.ff_proj)
-            # # weights
-            # if self.config.init_cutoff_factor is not None:
-            #     cutoff_value = self.config.init_cutoff_factor * self.config.init_std
-            #     nn.init.trunc_normal_(self.att_proj.weight, mean=0.0, std=self.config.init_std, a=-cutoff_value,
-            #                           b=cutoff_value)
-            #     nn.init.trunc_normal_(self.ff_proj.weight, mean=0.0, std=self.config.init_std, a=-cutoff_value,
-            #                           b=cutoff_value)
-            # else:
-            #     nn.init.normal_(self.att_proj.weight, mean=0.0, std=self.config.init_std)
-            #     nn.init.normal_(self.ff_proj.weight, mean=0.0, std=self.config.init_std)
-            #
-            # # biases
-            # if self.config.include_bias:
-            #     nn.init.zeros_(self.att_proj.bias)
-            #     nn.init.zeros_(self.ff_proj.bias)
         else:
             init_weights(
                 self.config, self.att_proj, d=self.config.d_model, layer_id=None, type_of_module=ModuleType.in_module
@@ -804,7 +790,7 @@ class OLMoLlamaBlock(OLMoBlock):
         self.ff_norm.reset_parameters()
         # NOTE: the standard deviation for these weights does not depend on the layer.
 
-        if self.config.init_fn == "normal":
+        if self.config.init_fn == InitFnType.normal:
             init_normal(self.config, self.q_proj)
             init_normal(self.config, self.k_proj)
             init_normal(self.config, self.v_proj)

--- a/olmo/model.py
+++ b/olmo/model.py
@@ -475,7 +475,6 @@ class OLMoBlock(nn.Module):
         if self.q_norm is not None:
             self.q_norm.reset_parameters()
 
-        # TOD0: move step by step
         if self.config.init_fn == InitFnType.normal:
             init_normal(self.attn_out, std=self.config.init_std, init_cutoff_factor=self.config.init_cutoff_factor)
             init_normal(self.ff_out, std=self.config.init_std, init_cutoff_factor=self.config.init_cutoff_factor)

--- a/olmo/model.py
+++ b/olmo/model.py
@@ -1110,7 +1110,7 @@ class OLMo(nn.Module):
                 ff_out_std = 1 / math.sqrt(self.config.d_model)
                 ff_out_cutoff_factor = 3.0
             elif self.config.init_fn == InitFnType.full_megatron:
-                ff_out_std = self.config.d_model**-0.5
+                ff_out_std = 1 / math.sqrt(self.config.d_model)
                 ff_out_cutoff_factor = self.config.init_cutoff_factor or 3.0
             else:
                 raise NotImplementedError(self.config.init_fn)

--- a/olmo/model.py
+++ b/olmo/model.py
@@ -1116,7 +1116,7 @@ class OLMo(nn.Module):
             else:
                 raise NotImplementedError(self.config.init_fn)
 
-        init_normal(self.transformer.ff_out, ff_out_std, ff_out_cutoff_factor)
+            init_normal(self.transformer.ff_out, ff_out_std, ff_out_cutoff_factor)
 
         # Let the blocks handle themselves.
         if self.config.block_group_size == 1:

--- a/olmo/model.py
+++ b/olmo/model.py
@@ -807,10 +807,10 @@ class OLMoLlamaBlock(OLMoBlock):
             init_mitchell(self.config, self.v_proj, layer_id=None)
             init_mitchell(self.config, self.ff_proj, layer_id=None)
         else:
-            init_weights(self.config, self.q_proj, d=self.config.d_model, layer_id=None)
-            init_weights(self.config, self.k_proj, d=self.config.d_model, layer_id=None)
-            init_weights(self.config, self.v_proj, d=self.config.d_model, layer_id=None)
-            init_weights(self.config, self.ff_proj, d=self.config.d_model, layer_id=None)
+            init_weights(self.config, self.q_proj, d=self.config.d_model, layer_id=None, type_of_module=ModuleType.in_module)
+            init_weights(self.config, self.k_proj, d=self.config.d_model, layer_id=None, type_of_module=ModuleType.in_module)
+            init_weights(self.config, self.v_proj, d=self.config.d_model, layer_id=None, type_of_module=ModuleType.in_module)
+            init_weights(self.config, self.ff_proj, d=self.config.d_model, layer_id=None, type_of_module=ModuleType.in_module)
 
     def _scaled_dot_product_attention(
         self,

--- a/olmo/model.py
+++ b/olmo/model.py
@@ -43,7 +43,7 @@ from .config import (
     ModelConfig,
 )
 from .exceptions import OLMoConfigurationError
-from .initialization import ModuleType, init_weights
+from .initialization import ModuleType, init_weights, init_normal
 from .torch_util import ensure_finite_
 
 if sys.version_info.minor > 8:
@@ -473,20 +473,35 @@ class OLMoBlock(nn.Module):
             self.k_norm.reset_parameters()
         if self.q_norm is not None:
             self.q_norm.reset_parameters()
-        init_weights(
-            self.config,
-            self.attn_out,
-            d=self.config.d_model,
-            layer_id=self.layer_id,
-            type_of_module=ModuleType.out_module,
-        )
-        init_weights(
-            self.config,
-            self.ff_out,
-            d=self.ff_out.in_features,
-            layer_id=self.layer_id,
-            type_of_module=ModuleType.out_module,
-        )
+
+        # TOD0: move step by step
+        if self.config.init_fn == "normal":
+            init_normal(self.config, self.attn_out)
+            init_normal(self.config, self.ff_out)
+
+            # TODO: what is up with this extra divisor? We may not want this.
+            # git blame rabbit hole:
+            #   https://github.com/allenai/OLMo/pull/239/commits/0c5b7b5ccac26c3e4729322520f1fdd5b0a4d54e#diff-14cdafe7342088f0c4851cc670185044902088ba6bc5ddcf0a464d698e4165fe
+            #   https://github.com/allenai/OLMo/commit/ba20a857fde0c2fb2e8dbcba07e3781fe088ba06
+            # This is for the case of ff_out._is_residual = True
+            with torch.no_grad():
+                self.ff_out.weight.div_(math.sqrt(2 * self.config.n_layers))
+
+        else:
+            init_weights(
+                self.config,
+                self.attn_out,
+                d=self.config.d_model,
+                layer_id=self.layer_id,
+                type_of_module=ModuleType.out_module,
+            )
+            init_weights(
+                self.config,
+                self.ff_out,
+                d=self.ff_out.in_features,
+                layer_id=self.layer_id,
+                type_of_module=ModuleType.out_module,
+            )
 
     def set_activation_checkpointing(self, strategy: Optional[ActivationCheckpointingStrategy]):
         if strategy == ActivationCheckpointingStrategy.fine_grained:
@@ -662,12 +677,32 @@ class OLMoSequentialBlock(OLMoBlock):
         self.attn_norm.reset_parameters()
         self.ff_norm.reset_parameters()
         # NOTE: the standard deviation for these weights does not depend on the layer.
-        init_weights(
-            self.config, self.att_proj, d=self.config.d_model, layer_id=None, type_of_module=ModuleType.in_module
-        )
-        init_weights(
-            self.config, self.ff_proj, d=self.config.d_model, layer_id=None, type_of_module=ModuleType.in_module
-        )
+
+        if self.config.init_fn == "normal":
+            init_normal(self.config, self.att_proj)
+            init_normal(self.config, self.ff_proj)
+            # # weights
+            # if self.config.init_cutoff_factor is not None:
+            #     cutoff_value = self.config.init_cutoff_factor * self.config.init_std
+            #     nn.init.trunc_normal_(self.att_proj.weight, mean=0.0, std=self.config.init_std, a=-cutoff_value,
+            #                           b=cutoff_value)
+            #     nn.init.trunc_normal_(self.ff_proj.weight, mean=0.0, std=self.config.init_std, a=-cutoff_value,
+            #                           b=cutoff_value)
+            # else:
+            #     nn.init.normal_(self.att_proj.weight, mean=0.0, std=self.config.init_std)
+            #     nn.init.normal_(self.ff_proj.weight, mean=0.0, std=self.config.init_std)
+            #
+            # # biases
+            # if self.config.include_bias:
+            #     nn.init.zeros_(self.att_proj.bias)
+            #     nn.init.zeros_(self.ff_proj.bias)
+        else:
+            init_weights(
+                self.config, self.att_proj, d=self.config.d_model, layer_id=None, type_of_module=ModuleType.in_module
+            )
+            init_weights(
+                self.config, self.ff_proj, d=self.config.d_model, layer_id=None, type_of_module=ModuleType.in_module
+            )
 
     def forward(
         self,
@@ -768,10 +803,17 @@ class OLMoLlamaBlock(OLMoBlock):
         self.attn_norm.reset_parameters()
         self.ff_norm.reset_parameters()
         # NOTE: the standard deviation for these weights does not depend on the layer.
-        init_weights(self.config, self.q_proj, d=self.config.d_model, layer_id=None)
-        init_weights(self.config, self.k_proj, d=self.config.d_model, layer_id=None)
-        init_weights(self.config, self.v_proj, d=self.config.d_model, layer_id=None)
-        init_weights(self.config, self.ff_proj, d=self.config.d_model, layer_id=None)
+
+        if self.config.init_fn == "normal":
+            init_normal(self.config, self.q_proj)
+            init_normal(self.config, self.k_proj)
+            init_normal(self.config, self.v_proj)
+            init_normal(self.config, self.ff_proj)
+        else:
+            init_weights(self.config, self.q_proj, d=self.config.d_model, layer_id=None)
+            init_weights(self.config, self.k_proj, d=self.config.d_model, layer_id=None)
+            init_weights(self.config, self.v_proj, d=self.config.d_model, layer_id=None)
+            init_weights(self.config, self.ff_proj, d=self.config.d_model, layer_id=None)
 
     def _scaled_dot_product_attention(
         self,
@@ -1020,12 +1062,19 @@ class OLMo(nn.Module):
     def reset_parameters(self):
         log.info("Initializing model parameters...")
         # Top-level embeddings / linear layers.
-        init_weights(
-            self.config,
-            self.transformer.wte,  # type: ignore
-            std_factor=(0.5 * math.sqrt(self.config.d_model)) if self.config.scale_logits else 1.0,
-            type_of_module=ModuleType.emb,
-        )
+
+        if self.config.init_fn == "normal":
+            init_normal(
+                self.config,
+                self.transformer.wte,
+                std_factor=(0.5 * math.sqrt(self.config.d_model)) if self.config.scale_logits else 1.0)
+        else:
+            init_weights(
+                self.config,
+                self.transformer.wte,  # type: ignore
+                std_factor=(0.5 * math.sqrt(self.config.d_model)) if self.config.scale_logits else 1.0,
+                type_of_module=ModuleType.emb,
+            )
         if hasattr(self.transformer, "wpe"):
             init_weights(self.config, self.transformer.wpe, type_of_module=ModuleType.emb)  # type: ignore
 

--- a/tests/initialization_test.py
+++ b/tests/initialization_test.py
@@ -54,9 +54,11 @@ def check_distribution(
         if min_val is not None:
             assert param.data.min() >= min_val
 
+
 #################################################################################
 ################################### OLMoBlock ###################################
 #################################################################################
+
 
 @pytest.mark.parametrize("seed", list(torch.randint(1, 10000, (3,))))
 def test_olmo_block_init_normal(seed: int):
@@ -90,8 +92,8 @@ def test_olmo_block_init_normal(seed: int):
     block.reset_parameters()
 
     # TODO: why is the diff higher?
-    check_distribution(block.attn_out, 0.00, 0.02, 3.0*0.02, -3.0*0.02, diff=1e-3)
-    check_distribution(block.ff_out, 0.00, 0.02 / math.sqrt(2 * n_layers), 3.0*0.02, -3.0*0.02, diff=1e-3)
+    check_distribution(block.attn_out, 0.00, 0.02, 3.0 * 0.02, -3.0 * 0.02, diff=1e-3)
+    check_distribution(block.ff_out, 0.00, 0.02 / math.sqrt(2 * n_layers), 3.0 * 0.02, -3.0 * 0.02, diff=1e-3)
 
     ## Scale embedding
 
@@ -115,8 +117,10 @@ def test_olmo_block_init_mitchell(seed: int):
         block.reset_parameters()
 
         # TODO: why is the diff higher?
-        check_distribution(block.attn_out, 0.00, 1/(math.sqrt(2*d_model*(layer_id+1))), diff=1e-3)
-        check_distribution(block.ff_out, 0.00, 1/(math.sqrt(2*block.ff_out.in_features*(layer_id+1))), diff=1e-3)
+        check_distribution(block.attn_out, 0.00, 1 / (math.sqrt(2 * d_model * (layer_id + 1))), diff=1e-3)
+        check_distribution(
+            block.ff_out, 0.00, 1 / (math.sqrt(2 * block.ff_out.in_features * (layer_id + 1))), diff=1e-3
+        )
 
 
 @pytest.mark.parametrize("seed", list(torch.randint(1, 10000, (3,))))
@@ -131,17 +135,26 @@ def test_olmo_block_init_full_megatron(seed: int):
     cache = BufferCache()
 
     for init_cutoff_factor in [None, 3]:
-        base_config = ModelConfig(d_model=d_model, n_heads=n_heads, n_layers=n_layers, init_fn="full_megatron", init_std=0.006, init_cutoff_factor=init_cutoff_factor)
+        base_config = ModelConfig(
+            d_model=d_model,
+            n_heads=n_heads,
+            n_layers=n_layers,
+            init_fn="full_megatron",
+            init_std=0.006,
+            init_cutoff_factor=init_cutoff_factor,
+        )
 
         for layer_id in [0, 4]:
             block = OLMoBlock(layer_id=layer_id, config=base_config, cache=cache)
             block.reset_parameters()
 
             # TODO: default init cutoff factor is 3. Should be configurable right? Should it ever be None for megatron?
-            check_distribution(block.attn_out, 0.00, 0.006 / math.sqrt(2.0 * n_layers), 3.0 * 0.006, -3.0 * 0.006,
-                               diff=1e-3)
-            check_distribution(block.ff_out, 0.00, 0.006 / math.sqrt(2.0 * n_layers), 3.0 * 0.006, -3.0 * 0.006,
-                               diff=1e-3)
+            check_distribution(
+                block.attn_out, 0.00, 0.006 / math.sqrt(2.0 * n_layers), 3.0 * 0.006, -3.0 * 0.006, diff=1e-3
+            )
+            check_distribution(
+                block.ff_out, 0.00, 0.006 / math.sqrt(2.0 * n_layers), 3.0 * 0.006, -3.0 * 0.006, diff=1e-3
+            )
 
     ## Scale embedding
 
@@ -149,6 +162,7 @@ def test_olmo_block_init_full_megatron(seed: int):
 #################################################################################
 ############################## OLMoSequentialBlock ##############################
 #################################################################################
+
 
 @pytest.mark.parametrize("seed", list(torch.randint(1, 10000, (3,))))
 def test_olmo_sequential_block_init_normal(seed: int):
@@ -194,8 +208,9 @@ def test_olmo_sequential_block_init_mitchell(seed: int):
 
         # TODO: why is the diff higher?
         check_distribution(block.attn_out, 0.00, 1 / (math.sqrt(2 * d_model * (layer_id + 1))), diff=1e-3)
-        check_distribution(block.ff_out, 0.00, 1 / (math.sqrt(2 * block.ff_out.in_features * (layer_id + 1))),
-                           diff=1e-3)
+        check_distribution(
+            block.ff_out, 0.00, 1 / (math.sqrt(2 * block.ff_out.in_features * (layer_id + 1))), diff=1e-3
+        )
         # if parametric layer norm
         check_distribution(block.attn_norm, 1.00, 0.00)
         check_distribution(block.ff_norm, 1.00, 0.00)
@@ -211,7 +226,9 @@ def test_olmo_sequential_block_init_full_megatron(seed: int):
 
     ################################################ Megatron init ################################################
     cache = BufferCache()
-    base_config = ModelConfig(d_model=d_model, n_heads=n_heads, n_layers=n_layers, init_fn="full_megatron", init_std=0.006)
+    base_config = ModelConfig(
+        d_model=d_model, n_heads=n_heads, n_layers=n_layers, init_fn="full_megatron", init_std=0.006
+    )
 
     for layer_id in [0, 4]:
         block = OLMoSequentialBlock(layer_id=layer_id, config=base_config, cache=cache)
@@ -226,6 +243,7 @@ def test_olmo_sequential_block_init_full_megatron(seed: int):
         # if parametric layer norm
         check_distribution(block.attn_norm, 1.00, 0.00)
         check_distribution(block.ff_norm, 1.00, 0.00)
+
 
 #################################################################################
 ################################ OLMoLlamaBlock #################################
@@ -273,8 +291,13 @@ def test_olmo_llama_block_init_mitchell(seed: int):
         block.reset_parameters()
 
         # TODO: why is diff higher?
-        check_distribution(block, 0.00, 1 / math.sqrt(d_model),
-                           ignore_params=["attn_out", "ff_out", "attn_norm", "ff_norm"], diff=1e-3)
+        check_distribution(
+            block,
+            0.00,
+            1 / math.sqrt(d_model),
+            ignore_params=["attn_out", "ff_out", "attn_norm", "ff_norm"],
+            diff=1e-3,
+        )
         # if parametric layer norm
         check_distribution(block.attn_norm, 1.00, 0.00)
         check_distribution(block.ff_norm, 1.00, 0.00)
@@ -290,7 +313,9 @@ def test_olmo_llama_block_init_full_megatron(seed: int):
 
     ################################################ Megatron init ################################################
     cache = BufferCache()
-    base_config = ModelConfig(d_model=d_model, n_heads=n_heads, n_layers=n_layers, init_fn="full_megatron", init_std=0.006)
+    base_config = ModelConfig(
+        d_model=d_model, n_heads=n_heads, n_layers=n_layers, init_fn="full_megatron", init_std=0.006
+    )
 
     for layer_id in [0, 4]:
         block = OLMoLlamaBlock(layer_id=layer_id, config=base_config, cache=cache)
@@ -312,6 +337,7 @@ def test_olmo_llama_block_init_full_megatron(seed: int):
 #################################################################################
 ##################################### OLMo ######################################
 #################################################################################
+
 
 @pytest.mark.parametrize("seed", list(torch.randint(1, 10000, (3,))))
 def test_olmo_init_normal(seed: int):
@@ -359,7 +385,7 @@ def test_olmo_init_normal(seed: int):
         check_distribution(module.transformer.blocks[i].ff_norm, 1.00, 0.00)
     check_distribution(module.transformer.ln_f, 1.00, 0.00)
     check_distribution(module.transformer.ff_out, 0.00, 0.02)
-    check_distribution(module.transformer.wte, 0.0, 0.02*0.5 * math.sqrt(d_model), diff=1e-3)
+    check_distribution(module.transformer.wte, 0.0, 0.02 * 0.5 * math.sqrt(d_model), diff=1e-3)
 
 
 @pytest.mark.parametrize("seed", list(torch.randint(1, 10000, (3,))))
@@ -380,11 +406,24 @@ def test_olmo_init_mitchell(seed: int):
     )
     module = OLMo(config=base_config, init_params=True)
 
-    check_distribution(module.transformer, 0.00, 1 / math.sqrt(d_model), ignore_params=["attn_out", "ff_out", "attn_norm", "ff_norm", "ln_f"], diff=1e-3)
+    check_distribution(
+        module.transformer,
+        0.00,
+        1 / math.sqrt(d_model),
+        ignore_params=["attn_out", "ff_out", "attn_norm", "ff_norm", "ln_f"],
+        diff=1e-3,
+    )
 
     for i in range(n_layers):
-        check_distribution(module.transformer.blocks[i].attn_out, 0.00, 1 / (math.sqrt(2 * d_model * (i + 1))), diff=1e-3)
-        check_distribution(module.transformer.blocks[i].ff_out, 0.00, 1 / (math.sqrt(2 * module.transformer.blocks[i].ff_out.in_features * (i + 1))), diff=1e-3)
+        check_distribution(
+            module.transformer.blocks[i].attn_out, 0.00, 1 / (math.sqrt(2 * d_model * (i + 1))), diff=1e-3
+        )
+        check_distribution(
+            module.transformer.blocks[i].ff_out,
+            0.00,
+            1 / (math.sqrt(2 * module.transformer.blocks[i].ff_out.in_features * (i + 1))),
+            diff=1e-3,
+        )
 
         check_distribution(module.transformer.blocks[i].attn_norm, 1.00, 0.00)
         check_distribution(module.transformer.blocks[i].ff_norm, 1.00, 0.00)
@@ -403,14 +442,24 @@ def test_olmo_init_mitchell(seed: int):
     )
     module = OLMo(config=base_config, init_params=True)
 
-    check_distribution(module.transformer, 0.00, 1 / math.sqrt(d_model),
-                       ignore_params=["attn_out", "ff_out", "attn_norm", "ff_norm", "ln_f", "wte"], diff=1e-3)
+    check_distribution(
+        module.transformer,
+        0.00,
+        1 / math.sqrt(d_model),
+        ignore_params=["attn_out", "ff_out", "attn_norm", "ff_norm", "ln_f", "wte"],
+        diff=1e-3,
+    )
 
     for i in range(n_layers):
-        check_distribution(module.transformer.blocks[i].attn_out, 0.00, 1 / (math.sqrt(2 * d_model * (i + 1))),
-                           diff=1e-3)
-        check_distribution(module.transformer.blocks[i].ff_out, 0.00,
-                           1 / (math.sqrt(2 * module.transformer.blocks[i].ff_out.in_features * (i + 1))), diff=1e-3)
+        check_distribution(
+            module.transformer.blocks[i].attn_out, 0.00, 1 / (math.sqrt(2 * d_model * (i + 1))), diff=1e-3
+        )
+        check_distribution(
+            module.transformer.blocks[i].ff_out,
+            0.00,
+            1 / (math.sqrt(2 * module.transformer.blocks[i].ff_out.in_features * (i + 1))),
+            diff=1e-3,
+        )
 
         check_distribution(module.transformer.blocks[i].attn_norm, 1.00, 0.00)
         check_distribution(module.transformer.blocks[i].ff_norm, 1.00, 0.00)

--- a/tests/initialization_test.py
+++ b/tests/initialization_test.py
@@ -5,7 +5,7 @@ import pytest
 import torch.nn
 from torch.testing import assert_close
 
-from olmo.config import ModelConfig
+from olmo.config import ModelConfig, InitFnType
 from olmo.model import BufferCache, OLMo, OLMoBlock, OLMoLlamaBlock, OLMoSequentialBlock
 from olmo.torch_util import seed_all
 
@@ -70,7 +70,7 @@ def test_olmo_block_init_normal(seed: int):
 
     ################################################ Normal init ################################################
     cache = BufferCache()
-    base_config = ModelConfig(d_model=d_model, n_heads=n_heads, n_layers=n_layers, init_fn="normal", init_std=0.02)
+    base_config = ModelConfig(d_model=d_model, n_heads=n_heads, n_layers=n_layers, init_fn=InitFnType.normal, init_std=0.02)
 
     for layer_id in [0, 4]:
         block = OLMoBlock(layer_id=layer_id, config=base_config, cache=cache)
@@ -84,7 +84,7 @@ def test_olmo_block_init_normal(seed: int):
         d_model=d_model,
         n_heads=n_heads,
         n_layers=n_layers,
-        init_fn="normal",
+        init_fn=InitFnType.normal,
         init_std=0.02,
         init_cutoff_factor=3.0,
     )
@@ -108,7 +108,7 @@ def test_olmo_block_init_mitchell(seed: int):
     ################################################ Mitchell init ################################################
 
     cache = BufferCache()
-    base_config = ModelConfig(d_model=d_model, n_heads=n_heads, n_layers=n_layers, init_fn="mitchell")
+    base_config = ModelConfig(d_model=d_model, n_heads=n_heads, n_layers=n_layers, init_fn=InitFnType.mitchell)
 
     # expected_std = 1/(math.sqrt(2*d*(layer_id+1))
 
@@ -139,7 +139,7 @@ def test_olmo_block_init_full_megatron(seed: int):
             d_model=d_model,
             n_heads=n_heads,
             n_layers=n_layers,
-            init_fn="full_megatron",
+            init_fn=InitFnType.full_megatron,
             init_std=0.006,
             init_cutoff_factor=init_cutoff_factor,
         )
@@ -174,7 +174,7 @@ def test_olmo_sequential_block_init_normal(seed: int):
 
     ################################################ Normal init ################################################
     cache = BufferCache()
-    base_config = ModelConfig(d_model=d_model, n_heads=n_heads, n_layers=n_layers, init_fn="normal", init_std=0.02)
+    base_config = ModelConfig(d_model=d_model, n_heads=n_heads, n_layers=n_layers, init_fn=InitFnType.normal, init_std=0.02)
 
     for layer_id in [0, 4]:
         block = OLMoSequentialBlock(layer_id=layer_id, config=base_config, cache=cache)
@@ -197,7 +197,7 @@ def test_olmo_sequential_block_init_mitchell(seed: int):
 
     ################################################ Mitchell init ################################################
     cache = BufferCache()
-    base_config = ModelConfig(d_model=d_model, n_heads=n_heads, n_layers=n_layers, init_fn="mitchell")
+    base_config = ModelConfig(d_model=d_model, n_heads=n_heads, n_layers=n_layers, init_fn=InitFnType.mitchell)
 
     for layer_id in [0, 4]:
         block = OLMoSequentialBlock(layer_id=layer_id, config=base_config, cache=cache)
@@ -227,7 +227,7 @@ def test_olmo_sequential_block_init_full_megatron(seed: int):
     ################################################ Megatron init ################################################
     cache = BufferCache()
     base_config = ModelConfig(
-        d_model=d_model, n_heads=n_heads, n_layers=n_layers, init_fn="full_megatron", init_std=0.006
+        d_model=d_model, n_heads=n_heads, n_layers=n_layers, init_fn=InitFnType.full_megatron, init_std=0.006
     )
 
     for layer_id in [0, 4]:
@@ -260,7 +260,7 @@ def test_olmo_llama_block_init_normal(seed: int):
 
     ################################################ Normal init ################################################
     cache = BufferCache()
-    base_config = ModelConfig(d_model=d_model, n_heads=n_heads, n_layers=n_layers, init_fn="normal", init_std=0.02)
+    base_config = ModelConfig(d_model=d_model, n_heads=n_heads, n_layers=n_layers, init_fn=InitFnType.normal, init_std=0.02)
 
     for layer_id in [0, 4]:
         block = OLMoLlamaBlock(layer_id=layer_id, config=base_config, cache=cache)
@@ -284,7 +284,7 @@ def test_olmo_llama_block_init_mitchell(seed: int):
     ################################################ Mitchell init ################################################
 
     cache = BufferCache()
-    base_config = ModelConfig(d_model=d_model, n_heads=n_heads, n_layers=n_layers, init_fn="mitchell")
+    base_config = ModelConfig(d_model=d_model, n_heads=n_heads, n_layers=n_layers, init_fn=InitFnType.mitchell)
 
     for layer_id in [0, 4]:
         block = OLMoLlamaBlock(layer_id=layer_id, config=base_config, cache=cache)
@@ -314,7 +314,7 @@ def test_olmo_llama_block_init_full_megatron(seed: int):
     ################################################ Megatron init ################################################
     cache = BufferCache()
     base_config = ModelConfig(
-        d_model=d_model, n_heads=n_heads, n_layers=n_layers, init_fn="full_megatron", init_std=0.006
+        d_model=d_model, n_heads=n_heads, n_layers=n_layers, init_fn=InitFnType.full_megatron, init_std=0.006
     )
 
     for layer_id in [0, 4]:
@@ -351,7 +351,7 @@ def test_olmo_init_normal(seed: int):
         d_model=d_model,
         n_heads=n_heads,
         n_layers=n_layers,
-        init_fn="normal",
+        init_fn=InitFnType.normal,
         init_std=0.02,
         scale_logits=False,
         weight_tying=False,
@@ -371,7 +371,7 @@ def test_olmo_init_normal(seed: int):
         d_model=d_model,
         n_heads=n_heads,
         n_layers=n_layers,
-        init_fn="normal",
+        init_fn=InitFnType.normal,
         init_std=0.02,
         scale_logits=True,
         weight_tying=False,
@@ -400,7 +400,7 @@ def test_olmo_init_mitchell(seed: int):
         d_model=d_model,
         n_heads=n_heads,
         n_layers=n_layers,
-        init_fn="mitchell",
+        init_fn=InitFnType.mitchell,
         scale_logits=False,
         weight_tying=False,
     )
@@ -438,7 +438,7 @@ def test_olmo_init_mitchell(seed: int):
         d_model=d_model,
         n_heads=n_heads,
         n_layers=n_layers,
-        init_fn="mitchell",
+        init_fn=InitFnType.mitchell,
         scale_logits=True,
         weight_tying=False,
     )
@@ -486,7 +486,7 @@ def test_olmo_init_full_megatron(seed: int):
         d_model=d_model,
         n_heads=n_heads,
         n_layers=n_layers,
-        init_fn="full_megatron",
+        init_fn=InitFnType.full_megatron,
         init_std=0.006,
         scale_logits=False,
         weight_tying=False,
@@ -511,7 +511,7 @@ def test_olmo_init_full_megatron(seed: int):
         d_model=d_model,
         n_heads=n_heads,
         n_layers=n_layers,
-        init_fn="full_megatron",
+        init_fn=InitFnType.full_megatron,
         init_std=0.006,
         scale_logits=True,
         weight_tying=False,

--- a/tests/initialization_test.py
+++ b/tests/initialization_test.py
@@ -146,13 +146,15 @@ def test_olmo_llama_block_init(seed: int):
     cache = BufferCache()
     base_config = ModelConfig(d_model=d_model, n_heads=n_heads, n_layers=n_layers, init_fn="normal", init_std=0.02)
 
-    block = OLMoSequentialBlock(layer_id=0, config=base_config, cache=cache)
+    block = OLMoLlamaBlock(layer_id=0, config=base_config, cache=cache)
     block.reset_parameters()
 
     check_distribution(block.attn_out, 0.00, 0.02)
     check_distribution(block.ff_out, 0.00, 0.02 / math.sqrt(2 * n_layers))
 
-    check_distribution(block.att_proj, 0.00, 0.02)
+    check_distribution(block.q_proj, 0.00, 0.02)
+    check_distribution(block.k_proj, 0.00, 0.02)
+    check_distribution(block.v_proj, 0.00, 0.02)
     check_distribution(block.ff_proj, 0.00, 0.02)
 
     # if parametric layer norm

--- a/tests/initialization_test.py
+++ b/tests/initialization_test.py
@@ -21,16 +21,15 @@ def check_distribution(
     ignore_params: Optional[List] = None,
 ):
     for name, param in module.named_parameters():
+        if ignore_params is not None and any([ignored in name for ignored in ignore_params]):
+            print(f"ignoring {name}")
+            continue
         if "bias" in name and bias_should_be_zero:
             expected_mean = 0.0
             expected_std = 0.0
         else:
             expected_mean = mean
             expected_std = std
-
-        if ignore_params is not None and any([ignored in name for ignored in ignore_params]):
-            print(f"ignoring {name}")
-            continue
 
         actual_mean = param.data.mean()
         actual_std = param.data.std()
@@ -57,7 +56,7 @@ def check_distribution(
 
 
 @pytest.mark.parametrize("seed", list(torch.randint(1, 10000, (3,))))
-def test_olmo_block_init(seed: int):
+def test_olmo_block_init_normal(seed: int):
     seed_all(seed)
 
     d_model = 1024
@@ -68,20 +67,14 @@ def test_olmo_block_init(seed: int):
     cache = BufferCache()
     base_config = ModelConfig(d_model=d_model, n_heads=n_heads, n_layers=n_layers, init_fn="normal", init_std=0.02)
 
-    block = OLMoBlock(layer_id=0, config=base_config, cache=cache)
-    block.reset_parameters()
+    for layer_id in [0, 4]:
+        block = OLMoBlock(layer_id=layer_id, config=base_config, cache=cache)
+        block.reset_parameters()
+        check_distribution(block.attn_out, 0.00, 0.02)
+        # TODO: confirm extra divisor; we may not want this.
+        check_distribution(block.ff_out, 0.00, 0.02 / math.sqrt(2 * n_layers))
 
-    check_distribution(block.attn_out, 0.00, 0.02)
-    # TODO: confirm extra divisor; we may not want this.
-    check_distribution(block.ff_out, 0.00, 0.02 / math.sqrt(2 * n_layers))
-
-    # layer_id should make no difference for normal init
-    block = OLMoBlock(layer_id=4, config=base_config, cache=cache)
-    block.reset_parameters()
-    check_distribution(block.attn_out, 0.00, 0.02)
-    check_distribution(block.ff_out, 0.00, 0.02 / math.sqrt(2 * n_layers))
-
-    ## truncated normal init
+    ########################################### Truncated Normal init ###########################################
     base_config = ModelConfig(
         d_model=d_model,
         n_heads=n_heads,
@@ -98,18 +91,34 @@ def test_olmo_block_init(seed: int):
     check_distribution(block.ff_out, 0.00, 0.02 / math.sqrt(2 * n_layers), 3.0*0.02, -3.0*0.02, diff=1e-3)
 
     ## full_megatron init
-    # base_config = ModelConfig(d_model=d_model, n_heads=n_heads, n_layers=n_layers, init_fn="full_megatron", init_std=0.02)
-    # block = OLMoBlock(layer_id=0, config=base_config, cache=cache)
-    # block.reset_parameters()
-    # check_distribution(block, 0.0, 0.02)
-
-    ## mitchell init
 
     ## Scale embedding
 
+@pytest.mark.parametrize("seed", list(torch.randint(1, 10000, (3,))))
+def test_olmo_block_init_mitchell(seed: int):
+    seed_all(seed)
+
+    d_model = 1024
+    n_heads = 2
+    n_layers = 2
+    ################################################ Mitchell init ################################################
+
+    cache = BufferCache()
+    base_config = ModelConfig(d_model=d_model, n_heads=n_heads, n_layers=n_layers, init_fn="mitchell")
+
+    # expected_std = 1/(math.sqrt(2*d*(layer_id+1))
+
+    for layer_id in [0, 4]:
+        block = OLMoBlock(layer_id=layer_id, config=base_config, cache=cache)
+        block.reset_parameters()
+
+        # TODO: why is the diff higher?
+        check_distribution(block.attn_out, 0.00, 1/(math.sqrt(2*d_model*(layer_id+1))), diff=1e-3)
+        check_distribution(block.ff_out, 0.00, 1/(math.sqrt(2*block.ff_out.in_features*(layer_id+1))), diff=1e-3)
+
 
 @pytest.mark.parametrize("seed", list(torch.randint(1, 10000, (3,))))
-def test_olmo_sequential_block_init(seed: int):
+def test_olmo_sequential_block_init_normal(seed: int):
     seed_all(seed)
 
     d_model = 1024
@@ -120,20 +129,48 @@ def test_olmo_sequential_block_init(seed: int):
     cache = BufferCache()
     base_config = ModelConfig(d_model=d_model, n_heads=n_heads, n_layers=n_layers, init_fn="normal", init_std=0.02)
 
-    block = OLMoSequentialBlock(layer_id=0, config=base_config, cache=cache)
-    block.reset_parameters()
+    for layer_id in [0, 4]:
+        block = OLMoSequentialBlock(layer_id=layer_id, config=base_config, cache=cache)
+        block.reset_parameters()
 
-    check_distribution(block.attn_out, 0.00, 0.02)
-    check_distribution(block.ff_out, 0.00, 0.02 / math.sqrt(2 * n_layers))
-    check_distribution(block.att_proj, 0.00, 0.02)
-    check_distribution(block.ff_proj, 0.00, 0.02)
-    # if parametric layer norm
-    check_distribution(block.attn_norm, 1.00, 0.00)
-    check_distribution(block.ff_norm, 1.00, 0.00)
+        check_distribution(block, 0.00, 0.02, ignore_params=["ff_out", "attn_norm", "ff_norm"])
+        check_distribution(block.ff_out, 0.00, 0.02 / math.sqrt(2 * n_layers))
+        # if parametric layer norm
+        check_distribution(block.attn_norm, 1.00, 0.00)
+        check_distribution(block.ff_norm, 1.00, 0.00)
 
 
 @pytest.mark.parametrize("seed", list(torch.randint(1, 10000, (3,))))
-def test_olmo_llama_block_init(seed: int):
+def test_olmo_sequential_block_init_mitchell(seed: int):
+    seed_all(seed)
+
+    d_model = 1024
+    n_heads = 2
+    n_layers = 2
+
+    ################################################ Mitchell init ################################################
+    cache = BufferCache()
+    base_config = ModelConfig(d_model=d_model, n_heads=n_heads, n_layers=n_layers, init_fn="mitchell")
+
+    for layer_id in [0, 4]:
+        block = OLMoSequentialBlock(layer_id=layer_id, config=base_config, cache=cache)
+        block.reset_parameters()
+
+        check_distribution(block.att_proj, 0.0, 1 / math.sqrt(d_model), diff=1e-3)
+        check_distribution(block.ff_proj, 0.0, 1 / math.sqrt(d_model), diff=1e-3)
+
+        # TODO: why is the diff higher?
+        check_distribution(block.attn_out, 0.00, 1 / (math.sqrt(2 * d_model * (layer_id + 1))), diff=1e-3)
+        check_distribution(block.ff_out, 0.00, 1 / (math.sqrt(2 * block.ff_out.in_features * (layer_id + 1))),
+                           diff=1e-3)
+        # if parametric layer norm
+        check_distribution(block.attn_norm, 1.00, 0.00)
+        check_distribution(block.ff_norm, 1.00, 0.00)
+
+
+
+@pytest.mark.parametrize("seed", list(torch.randint(1, 10000, (3,))))
+def test_olmo_llama_block_init_normal(seed: int):
     seed_all(seed)
 
     d_model = 1024
@@ -144,22 +181,43 @@ def test_olmo_llama_block_init(seed: int):
     cache = BufferCache()
     base_config = ModelConfig(d_model=d_model, n_heads=n_heads, n_layers=n_layers, init_fn="normal", init_std=0.02)
 
-    block = OLMoLlamaBlock(layer_id=0, config=base_config, cache=cache)
-    block.reset_parameters()
+    for layer_id in [0, 4]:
+        block = OLMoLlamaBlock(layer_id=layer_id, config=base_config, cache=cache)
+        block.reset_parameters()
 
-    check_distribution(block.attn_out, 0.00, 0.02)
-    check_distribution(block.ff_out, 0.00, 0.02 / math.sqrt(2 * n_layers))
-    check_distribution(block.q_proj, 0.00, 0.02)
-    check_distribution(block.k_proj, 0.00, 0.02)
-    check_distribution(block.v_proj, 0.00, 0.02)
-    check_distribution(block.ff_proj, 0.00, 0.02)
-    # if parametric layer norm
-    check_distribution(block.attn_norm, 1.00, 0.00)
-    check_distribution(block.ff_norm, 1.00, 0.00)
+        # TODO
+        check_distribution(block, 0.00, 0.02, ignore_params=["ff_out", "attn_norm", "ff_norm"])
+        check_distribution(block.ff_out, 0.00, 0.02 / math.sqrt(2 * n_layers))
+        # if parametric layer norm
+        check_distribution(block.attn_norm, 1.00, 0.00)
+        check_distribution(block.ff_norm, 1.00, 0.00)
 
 
 @pytest.mark.parametrize("seed", list(torch.randint(1, 10000, (3,))))
-def test_olmo_init(seed: int):
+def test_olmo_llama_block_init_mitchell(seed: int):
+    seed_all(seed)
+
+    d_model = 1024
+    n_heads = 2
+    n_layers = 2
+    ################################################ Mitchell init ################################################
+
+    cache = BufferCache()
+    base_config = ModelConfig(d_model=d_model, n_heads=n_heads, n_layers=n_layers, init_fn="mitchell")
+
+    for layer_id in [0, 4]:
+        block = OLMoLlamaBlock(layer_id=layer_id, config=base_config, cache=cache)
+        block.reset_parameters()
+
+        # TODO: why is diff higher?
+        check_distribution(block, 0.00, 1 / math.sqrt(d_model),
+                           ignore_params=["attn_out", "ff_out", "attn_norm", "ff_norm"], diff=1e-3)
+        # if parametric layer norm
+        check_distribution(block.attn_norm, 1.00, 0.00)
+        check_distribution(block.ff_norm, 1.00, 0.00)
+
+@pytest.mark.parametrize("seed", list(torch.randint(1, 10000, (3,))))
+def test_olmo_init_normal(seed: int):
     d_model = 1024
     n_heads = 2
     n_layers = 2
@@ -204,4 +262,64 @@ def test_olmo_init(seed: int):
         check_distribution(module.transformer.blocks[i].ff_norm, 1.00, 0.00)
     check_distribution(module.transformer.ln_f, 1.00, 0.00)
     check_distribution(module.transformer.ff_out, 0.00, 0.02)
-    check_distribution(module.transformer.wte, 0.0, 0.02*0.5 * math.sqrt(d_model))
+    check_distribution(module.transformer.wte, 0.0, 0.02*0.5 * math.sqrt(d_model), diff=1e-3)
+
+
+@pytest.mark.parametrize("seed", list(torch.randint(1, 10000, (3,))))
+def test_olmo_init_mitchell(seed: int):
+    d_model = 1024
+    n_heads = 2
+    n_layers = 2
+
+    ################################################ Normal init ################################################
+
+    base_config = ModelConfig(
+        d_model=d_model,
+        n_heads=n_heads,
+        n_layers=n_layers,
+        init_fn="mitchell",
+        scale_logits=False,
+        weight_tying=False,
+    )
+    module = OLMo(config=base_config, init_params=True)
+
+    check_distribution(module.transformer, 0.00, 1 / math.sqrt(d_model), ignore_params=["attn_out", "ff_out", "attn_norm", "ff_norm", "ln_f"], diff=1e-3)
+
+    for i in range(n_layers):
+        check_distribution(module.transformer.blocks[i].attn_out, 0.00, 1 / (math.sqrt(2 * d_model * (i + 1))), diff=1e-3)
+        check_distribution(module.transformer.blocks[i].ff_out, 0.00, 1 / (math.sqrt(2 * module.transformer.blocks[i].ff_out.in_features * (i + 1))), diff=1e-3)
+
+        check_distribution(module.transformer.blocks[i].attn_norm, 1.00, 0.00)
+        check_distribution(module.transformer.blocks[i].ff_norm, 1.00, 0.00)
+
+    check_distribution(module.transformer.ln_f, 1.00, 0.00)
+    check_distribution(module.transformer.ff_out, 0.00, 1 / math.sqrt(d_model), diff=1e-3)
+
+    # # scale logits
+    base_config = ModelConfig(
+        d_model=d_model,
+        n_heads=n_heads,
+        n_layers=n_layers,
+        init_fn="mitchell",
+        scale_logits=True,
+        weight_tying=False,
+    )
+    module = OLMo(config=base_config, init_params=True)
+
+    check_distribution(module.transformer, 0.00, 1 / math.sqrt(d_model),
+                       ignore_params=["attn_out", "ff_out", "attn_norm", "ff_norm", "ln_f", "wte"], diff=1e-3)
+
+    for i in range(n_layers):
+        check_distribution(module.transformer.blocks[i].attn_out, 0.00, 1 / (math.sqrt(2 * d_model * (i + 1))),
+                           diff=1e-3)
+        check_distribution(module.transformer.blocks[i].ff_out, 0.00,
+                           1 / (math.sqrt(2 * module.transformer.blocks[i].ff_out.in_features * (i + 1))), diff=1e-3)
+
+        check_distribution(module.transformer.blocks[i].attn_norm, 1.00, 0.00)
+        check_distribution(module.transformer.blocks[i].ff_norm, 1.00, 0.00)
+
+    check_distribution(module.transformer.ln_f, 1.00, 0.00)
+    check_distribution(module.transformer.ff_out, 0.00, 1 / math.sqrt(d_model), diff=1e-3)
+
+    # TODO: this seems buggy!! This will always be 0.5
+    check_distribution(module.transformer.wte, 0.0, (0.5 * math.sqrt(d_model)) / math.sqrt(d_model), diff=1e-2)

--- a/tests/initialization_test.py
+++ b/tests/initialization_test.py
@@ -5,7 +5,7 @@ import pytest
 import torch.nn
 from torch.testing import assert_close
 
-from olmo.config import ModelConfig, InitFnType
+from olmo.config import InitFnType, ModelConfig
 from olmo.model import BufferCache, OLMo, OLMoBlock, OLMoLlamaBlock, OLMoSequentialBlock
 from olmo.torch_util import seed_all
 
@@ -70,7 +70,9 @@ def test_olmo_block_init_normal(seed: int):
 
     ################################################ Normal init ################################################
     cache = BufferCache()
-    base_config = ModelConfig(d_model=d_model, n_heads=n_heads, n_layers=n_layers, init_fn=InitFnType.normal, init_std=0.02)
+    base_config = ModelConfig(
+        d_model=d_model, n_heads=n_heads, n_layers=n_layers, init_fn=InitFnType.normal, init_std=0.02
+    )
 
     for layer_id in [0, 4]:
         block = OLMoBlock(layer_id=layer_id, config=base_config, cache=cache)
@@ -174,7 +176,9 @@ def test_olmo_sequential_block_init_normal(seed: int):
 
     ################################################ Normal init ################################################
     cache = BufferCache()
-    base_config = ModelConfig(d_model=d_model, n_heads=n_heads, n_layers=n_layers, init_fn=InitFnType.normal, init_std=0.02)
+    base_config = ModelConfig(
+        d_model=d_model, n_heads=n_heads, n_layers=n_layers, init_fn=InitFnType.normal, init_std=0.02
+    )
 
     for layer_id in [0, 4]:
         block = OLMoSequentialBlock(layer_id=layer_id, config=base_config, cache=cache)
@@ -260,13 +264,14 @@ def test_olmo_llama_block_init_normal(seed: int):
 
     ################################################ Normal init ################################################
     cache = BufferCache()
-    base_config = ModelConfig(d_model=d_model, n_heads=n_heads, n_layers=n_layers, init_fn=InitFnType.normal, init_std=0.02)
+    base_config = ModelConfig(
+        d_model=d_model, n_heads=n_heads, n_layers=n_layers, init_fn=InitFnType.normal, init_std=0.02
+    )
 
     for layer_id in [0, 4]:
         block = OLMoLlamaBlock(layer_id=layer_id, config=base_config, cache=cache)
         block.reset_parameters()
 
-        # TODO
         check_distribution(block, 0.00, 0.02, ignore_params=["ff_out", "attn_norm", "ff_norm"])
         check_distribution(block.ff_out, 0.00, 0.02 / math.sqrt(2 * n_layers))
         # if parametric layer norm

--- a/tests/initialization_test.py
+++ b/tests/initialization_test.py
@@ -430,6 +430,8 @@ def test_olmo_init_mitchell(seed: int):
 
     check_distribution(module.transformer.ln_f, 1.00, 0.00)
     check_distribution(module.transformer.ff_out, 0.00, 1 / math.sqrt(d_model), diff=1e-3)
+    check_distribution(module.transformer.wte, 0.0, 1 / math.sqrt(d_model), diff=1e-3)
+    check_distribution(module.transformer.wpe, 0.0, 1 / math.sqrt(d_model), diff=1e-3)
 
     # # scale logits
     base_config = ModelConfig(
@@ -469,6 +471,7 @@ def test_olmo_init_mitchell(seed: int):
 
     # TODO: this seems buggy!! This will always be 0.5
     check_distribution(module.transformer.wte, 0.0, (0.5 * math.sqrt(d_model)) / math.sqrt(d_model), diff=1e-2)
+    check_distribution(module.transformer.wpe, 0.0, 1 / math.sqrt(d_model), diff=1e-2)
 
 
 @pytest.mark.parametrize("seed", list(torch.randint(1, 10000, (3,))))
@@ -500,6 +503,9 @@ def test_olmo_init_full_megatron(seed: int):
     check_distribution(module.transformer.ln_f, 1.00, 0.00)
     check_distribution(module.transformer.ff_out, 0.00, d_model**-0.5, diff=1e-3)
 
+    check_distribution(module.transformer.wte, 0.0, 0.006, diff=1e-3)
+    check_distribution(module.transformer.wpe, 0.0, 0.006)
+
     # scale logits
     base_config = ModelConfig(
         d_model=d_model,
@@ -522,3 +528,4 @@ def test_olmo_init_full_megatron(seed: int):
     check_distribution(module.transformer.ln_f, 1.00, 0.00)
     check_distribution(module.transformer.ff_out, 0.00, d_model**-0.5, diff=1e-3)
     check_distribution(module.transformer.wte, 0.0, 0.006, diff=1e-3)
+    check_distribution(module.transformer.wpe, 0.0, 0.006, diff=1e-3)

--- a/tests/initialization_test.py
+++ b/tests/initialization_test.py
@@ -1,0 +1,191 @@
+import math
+from typing import List, Optional
+
+import pytest
+import torch.nn
+from torch.testing import assert_close
+
+from olmo.config import ModelConfig
+from olmo.model import BufferCache, OLMo, OLMoBlock, OLMoLlamaBlock, OLMoSequentialBlock
+from olmo.torch_util import seed_all
+
+
+def check_distribution(
+    module: torch.nn.Module,
+    mean: float,
+    std: float,
+    max_val: Optional[float] = None,
+    min_val: Optional[float] = None,
+    bias_should_be_zero: bool = True,
+    diff: float = 1e-4,
+    ignore_params: Optional[List] = None,
+):
+    for name, param in module.named_parameters():
+        if "bias" in name and bias_should_be_zero:
+            expected_mean = 0.0
+            expected_std = 0.0
+        else:
+            expected_mean = mean
+            expected_std = std
+
+        if ignore_params is not None and any([ignored in name for ignored in ignore_params]):
+            print(f"ignoring {name}")
+            continue
+
+        actual_mean = param.data.mean()
+        actual_std = param.data.std()
+
+        assert_close(
+            actual_mean,
+            torch.tensor(expected_mean),
+            atol=diff,
+            rtol=diff,
+            msg=f"Expected mean value for {name} = {expected_mean}, actual = {actual_mean}",
+        )
+        assert_close(
+            actual_std,
+            torch.tensor(expected_std),
+            atol=diff,
+            rtol=diff,
+            msg=f"Expected std value for {name} = {expected_std}, actual = {actual_std}",
+        )
+
+        if max_val is not None:
+            assert param.data.max() <= max_val
+        if min_val is not None:
+            assert param.data.min() >= min_val
+
+
+@pytest.mark.parametrize("seed", list(torch.randint(1, 10000, (3,))))
+def test_olmo_block_init(seed: int):
+    seed_all(seed)
+
+    d_model = 1024
+    n_heads = 2
+    n_layers = 2
+
+    ################################################ Normal init ################################################
+    cache = BufferCache()
+    base_config = ModelConfig(d_model=d_model, n_heads=n_heads, n_layers=n_layers, init_fn="normal", init_std=0.02)
+
+    block = OLMoBlock(layer_id=0, config=base_config, cache=cache)
+    block.reset_parameters()
+
+    check_distribution(block.attn_out, 0.00, 0.02)
+    # TODO: confirm extra divisor; we may not want this.
+    check_distribution(block.ff_out, 0.00, 0.02 / math.sqrt(2 * n_layers))
+
+    # layer_id should make no difference for normal init
+    block = OLMoBlock(layer_id=4, config=base_config, cache=cache)
+    block.reset_parameters()
+    check_distribution(block.attn_out, 0.00, 0.02)
+    check_distribution(block.ff_out, 0.00, 0.02 / math.sqrt(2 * n_layers))
+
+    ## truncated normal init
+    base_config = ModelConfig(
+        d_model=d_model,
+        n_heads=n_heads,
+        n_layers=n_layers,
+        init_fn="normal",
+        init_std=0.02,
+        init_cutoff_factor=3.0,
+    )
+    block = OLMoBlock(layer_id=0, config=base_config, cache=cache)
+    block.reset_parameters()
+
+    # TODO: why is the diff higher?
+    check_distribution(block.attn_out, 0.00, 0.02, 3.0*0.02, -3.0*0.02, diff=1e-3)
+    check_distribution(block.ff_out, 0.00, 0.02 / math.sqrt(2 * n_layers), 3.0*0.02, -3.0*0.02, diff=1e-3)
+
+    ## full_megatron init
+    # base_config = ModelConfig(d_model=d_model, n_heads=n_heads, n_layers=n_layers, init_fn="full_megatron", init_std=0.02)
+    # block = OLMoBlock(layer_id=0, config=base_config, cache=cache)
+    # block.reset_parameters()
+    # check_distribution(block, 0.0, 0.02)
+
+    ## mitchell init
+
+    ## Scale embedding
+
+
+@pytest.mark.parametrize("seed", list(torch.randint(1, 10000, (3,))))
+def test_olmo_sequential_block_init(seed: int):
+    seed_all(seed)
+
+    d_model = 1024
+    n_heads = 2
+    n_layers = 2
+
+    ################################################ Normal init ################################################
+    cache = BufferCache()
+    base_config = ModelConfig(d_model=d_model, n_heads=n_heads, n_layers=n_layers, init_fn="normal", init_std=0.02)
+
+    block = OLMoSequentialBlock(layer_id=0, config=base_config, cache=cache)
+    block.reset_parameters()
+
+    check_distribution(block.attn_out, 0.00, 0.02)
+    check_distribution(block.ff_out, 0.00, 0.02 / math.sqrt(2 * n_layers))
+
+    check_distribution(block.att_proj, 0.00, 0.02)
+    check_distribution(block.ff_proj, 0.00, 0.02)
+
+    # if parametric layer norm
+    check_distribution(block.attn_norm, 1.00, 0.00)
+    check_distribution(block.ff_norm, 1.00, 0.00)
+
+
+@pytest.mark.parametrize("seed", list(torch.randint(1, 10000, (3,))))
+def test_olmo_llama_block_init(seed: int):
+    seed_all(seed)
+
+    d_model = 1024
+    n_heads = 2
+    n_layers = 2
+
+    ################################################ Normal init ################################################
+    cache = BufferCache()
+    base_config = ModelConfig(d_model=d_model, n_heads=n_heads, n_layers=n_layers, init_fn="normal", init_std=0.02)
+
+    block = OLMoSequentialBlock(layer_id=0, config=base_config, cache=cache)
+    block.reset_parameters()
+
+    check_distribution(block.attn_out, 0.00, 0.02)
+    check_distribution(block.ff_out, 0.00, 0.02 / math.sqrt(2 * n_layers))
+
+    check_distribution(block.att_proj, 0.00, 0.02)
+    check_distribution(block.ff_proj, 0.00, 0.02)
+
+    # if parametric layer norm
+    check_distribution(block.attn_norm, 1.00, 0.00)
+    check_distribution(block.ff_norm, 1.00, 0.00)
+
+
+@pytest.mark.parametrize("seed", list(torch.randint(1, 10000, (3,))))
+def test_olmo_init(seed: int):
+    d_model = 1024
+    n_heads = 2
+    n_layers = 2
+
+    ## normal init
+
+    base_config = ModelConfig(
+        d_model=d_model,
+        n_heads=n_heads,
+        n_layers=n_layers,
+        init_fn="normal",
+        init_std=0.02,
+        scale_logits=False,
+        weight_tying=False,
+    )
+    module = OLMo(config=base_config, init_params=True)
+
+    check_distribution(module, 0.0, 0.02, ignore_params=["ff_out", "ln_f", "attn_norm", "ff_norm"])
+
+    for i in range(n_layers):
+        check_distribution(module.transformer.blocks[i].ff_out, 0.00, 0.02 / math.sqrt(2 * n_layers))
+        check_distribution(module.transformer.blocks[i].attn_norm, 1.00, 0.00)
+        check_distribution(module.transformer.blocks[i].ff_norm, 1.00, 0.00)
+
+    check_distribution(module.transformer.ln_f, 1.00, 0.00)
+    check_distribution(module.transformer.ff_out, 0.00, 0.02)
+    # TODO: wpe, scale_logits, std_factor, etc.


### PR DESCRIPTION
Simplifies our inscrutable initialization

* IMPORTANT: currently, the implementation matches the old buggy values for init in several places. See below.
* Removes `init_weights` with its complex if-else logic.
* Adds `init_normal` which only takes the module, the std, and optionally a cutoff_factor.
* std and cutoff_factor computation is now handled in each module's `reset_parameters()`
* Adds unit tests for initialization.
* Removes implementation for `kaiming_normal` and `fan_in` InitFnType as these aren't being used anywhere. Can be added later if needed.


Potential bugs found in initialization as a result of the refactoring (these will be fixed after feedback):

- [x] `OLMoBlock.ff_out`'s `normal` initialization [multiples std by an extra factor](https://github.com/allenai/OLMo/pull/607/files#diff-ef8ab7279deeec716e70a1cc9ab2accaaa60f27b301cc0733f1e00a9e39c07d1R483-R490) of `1 / math.sqrt(2 * self.config.n_layers`. This potentially came from trying to incorporate `full_megatron` into the same function. 
- [x] Hardcoded values: `mitchell` hardcodes a cutoff_factor of 3.0 (always truncated_normal_ with 3.0). `full_megatron` hardcodes a default cutoff_factor of 3.0 (truncated_normal_ with `config.init_cutoff_factor or 3.0`). Again, this may be a result of trying to incorporate multiple inits into the same function. Ideally, the cutoff_factor should always come from the configurable `config.init_cutoff_factor`; do we _want_ to set always this value to 3.0 for mitchell and megatron?
- [ ] Need clarification: Why do we [scale the embedding](https://github.com/allenai/OLMo/pull/607/files#diff-ef8ab7279deeec716e70a1cc9ab2accaaa60f27b301cc0733f1e00a9e39c07d1R1071) with the following factor if `scale_logits=True`?
        `emb_std_factor = (0.5 * math.sqrt(self.config.d_model)) if self.config.scale_logits else 1.0`
- [ ] Additionally, in case of `mitchell` init, due to supplying the factor at multiple places in the old code, [std ends up always being 0.5](https://github.com/allenai/OLMo/pull/607/files#diff-ef8ab7279deeec716e70a1cc9ab2accaaa60f27b301cc0733f1e00a9e39c07d1R1077) when `scale_logits=True`!
