### PR TITLE
HF dataset loading optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added clipping fix to `Optimizer` class to make it work with FSDP `no_shard` and DDP.
 - Added tests to compare grad norm differences between torch optimizer and clipping and OLMo optimizer and clipping on both CPU and GPU.
-- Expose memmap dtype in data config 
+- Expose memmap dtype in data config
+- Added caching to disk of HF datasets used in downstream evals
 
 ### Changed
 

--- a/olmo/config.py
+++ b/olmo/config.py
@@ -1098,6 +1098,11 @@ class TrainConfig(BaseConfig):
     Whether to use the fused CE loss function from `flash-attn`.
     """
 
+    hf_datasets_cache_dir: Optional[str] = None
+    """
+    Path to cache directory of HF datasets saved with `datasets.save_to_disk`.
+    """
+
     @property
     def autocast_precision(self) -> torch.dtype:
         if self.precision == "amp_bf16":

--- a/olmo/eval/__init__.py
+++ b/olmo/eval/__init__.py
@@ -32,7 +32,9 @@ def build_downstream_evaluator(
     task_class = label_to_task_map[eval_cfg.label]
     if isinstance(task_class, tuple):
         task_class, task_kwargs = task_class
-    ds_eval_dataset = task_class(tokenizer=tokenizer, **task_kwargs)  # type: ignore
+    ds_eval_dataset = task_class(
+        tokenizer=tokenizer, datasets_cache_dir=train_config.hf_datasets_cache_dir, **task_kwargs
+    )  # type: ignore
     data_config = eval_cfg.data
     if is_unit_test:
         ds_eval_sampler = None

--- a/olmo/eval/__init__.py
+++ b/olmo/eval/__init__.py
@@ -34,7 +34,7 @@ def build_downstream_evaluator(
         task_class, task_kwargs = task_class
     ds_eval_dataset = task_class(
         tokenizer=tokenizer, datasets_cache_dir=train_config.hf_datasets_cache_dir, **task_kwargs
-    )  # type: ignore
+    )
     data_config = eval_cfg.data
     if is_unit_test:
         ds_eval_sampler = None

--- a/olmo/eval/__init__.py
+++ b/olmo/eval/__init__.py
@@ -34,7 +34,7 @@ def build_downstream_evaluator(
         task_class, task_kwargs = task_class
     ds_eval_dataset = task_class(
         tokenizer=tokenizer, datasets_cache_dir=train_config.hf_datasets_cache_dir, **task_kwargs
-    )
+    )  # type: ignore
     data_config = eval_cfg.data
     if is_unit_test:
         ds_eval_sampler = None

--- a/olmo/eval/downstream.py
+++ b/olmo/eval/downstream.py
@@ -18,36 +18,35 @@ log = logging.getLogger(__name__)
 
 
 def load_dataset(path, name, split, datasets_cache_dir: Optional[str] = None):
-    # Try get dataset from disk.
-    if datasets_cache_dir is not None:
-        try:
-            return load_dataset_from_disk(path, name, split, datasets_cache_dir)
-        except FileNotFoundError:
-            log.info(
-                "Path %s name %s split %s not present in local dir %s, loading from online",
-                path,
-                name,
-                split,
-                datasets_cache_dir,
-            )
-        # Barrier here to stop the case where FS rank 0 saves the dataset to disk before some non-zero
-        # ranks try getting the dataset from disk. This would cause those non-zero ranks to bypass
-        # the next barrier and cause rank 0 to be stuck at that barrier.
-        barrier()
-
     dataset = None
-    # Download and save the dataset, only once per FS. When a local datasets dir is not set,
-    # this will hopefully cache the datasets for use in other FS ranks.
+
+    # First try to load dataset on only FS rank 0, to avoid unnecessary network load.
+    # This will hopefully cache the dataset for use in other FS ranks.
     if get_fs_local_rank() == 0:
-        dataset = datasets.load_dataset(
-            path=path,
-            name=name,
-            split=split,
-            trust_remote_code=True,
-        )
-        assert isinstance(dataset, (datasets.DatasetDict, datasets.Dataset))
+        # Try get dataset from disk.
         if datasets_cache_dir is not None:
-            save_dataset_to_disk(dataset, path, name, split, datasets_cache_dir)
+            try:
+                dataset = load_dataset_from_disk(path, name, split, datasets_cache_dir)
+            except FileNotFoundError:
+                log.info(
+                    "Path %s name %s split %s not present in local dir %s, loading from online",
+                    path,
+                    name,
+                    split,
+                    datasets_cache_dir,
+                )
+
+        # Get dataset from online if not available on disk
+        if dataset is None:
+            dataset = datasets.load_dataset(
+                path=path,
+                name=name,
+                split=split,
+                trust_remote_code=True,
+            )
+            assert isinstance(dataset, (datasets.DatasetDict, datasets.Dataset))
+            if datasets_cache_dir is not None:
+                save_dataset_to_disk(dataset, path, name, split, datasets_cache_dir)
     barrier()
 
     # Dataset is loaded in FS rank 0

--- a/olmo/eval/downstream.py
+++ b/olmo/eval/downstream.py
@@ -208,6 +208,7 @@ class ICLMultiChoiceTaskDataset(metaclass=abc.ABCMeta):
         tokenizer: Tokenizer,
         dataset_path: str,
         dataset_name: Union[str, Sequence[str], None] = None,
+        datasets_cache_dir: Optional[str] = None,
         model_ctx_len: int = 2048,
         split="validation",
         prompts=[None],  # List of prompt variants to use
@@ -231,14 +232,8 @@ class ICLMultiChoiceTaskDataset(metaclass=abc.ABCMeta):
 
         dataset_list = []
         for ds_name in dataset_names:
-            dataset_list.append(
-                datasets.load_dataset(
-                    path=self.dataset_path,
-                    name=ds_name,
-                    split=split,
-                    trust_remote_code=True,
-                )
-            )
+            dataset = load_dataset(self.dataset_path, ds_name, split, datasets_cache_dir)
+            dataset_list.append(dataset)
         self.dataset = datasets.concatenate_datasets(dataset_list)
 
         # prep examples
@@ -453,11 +448,14 @@ class PIQA(ICLMultiChoiceTaskDataset):
 
     metric_type = "len_norm"
 
-    def __init__(self, tokenizer, dataset_path="piqa", dataset_name="plain_text"):
+    def __init__(
+        self, tokenizer, dataset_path="piqa", dataset_name="plain_text", datasets_cache_dir: Optional[str] = None
+    ):
         super().__init__(
             tokenizer=tokenizer,
             dataset_path=dataset_path,
             dataset_name=dataset_name,
+            datasets_cache_dir=datasets_cache_dir,
         )
 
     def doc_to_text(self, doc):
@@ -491,11 +489,14 @@ class HellaSwag(ICLMultiChoiceTaskDataset):
 
     metric_type = "len_norm"
 
-    def __init__(self, tokenizer, dataset_path="hellaswag", dataset_name=None):
+    def __init__(
+        self, tokenizer, dataset_path="hellaswag", dataset_name=None, datasets_cache_dir: Optional[str] = None
+    ):
         super().__init__(
             tokenizer=tokenizer,
             dataset_path=dataset_path,
             dataset_name=dataset_name,
+            datasets_cache_dir=datasets_cache_dir,
         )
 
     @classmethod
@@ -549,12 +550,19 @@ class WinoGrande(ICLMultiChoiceTaskDataset):
 
     metric_type = "acc"
 
-    def __init__(self, tokenizer, dataset_path="winogrande", dataset_name="winogrande_xl"):
+    def __init__(
+        self,
+        tokenizer,
+        dataset_path="winogrande",
+        dataset_name="winogrande_xl",
+        datasets_cache_dir: Optional[str] = None,
+    ):
         # all winogrande datasets have same val set
         super().__init__(
             tokenizer=tokenizer,
             dataset_path=dataset_path,
             dataset_name=dataset_name,
+            datasets_cache_dir=datasets_cache_dir,
         )
 
     def prep_examples(self):
@@ -644,11 +652,14 @@ class OpenBookQA(ICLMultiChoiceTaskDataset):
 
     metric_type = "len_norm"
 
-    def __init__(self, tokenizer, dataset_path="openbookqa", dataset_name="main"):
+    def __init__(
+        self, tokenizer, dataset_path="openbookqa", dataset_name="main", datasets_cache_dir: Optional[str] = None
+    ):
         super().__init__(
             tokenizer=tokenizer,
             dataset_path=dataset_path,
             dataset_name=dataset_name,
+            datasets_cache_dir=datasets_cache_dir,
         )
 
     def doc_to_text(self, doc):
@@ -679,11 +690,14 @@ class BoolQ(ICLMultiChoiceTaskDataset):
 
     metric_type = "acc"
 
-    def __init__(self, tokenizer, dataset_path="boolq", dataset_name=None):
+    def __init__(
+        self, tokenizer, dataset_path="boolq", dataset_name=None, datasets_cache_dir: Optional[str] = None
+    ):
         super().__init__(
             tokenizer=tokenizer,
             dataset_path=dataset_path,
             dataset_name=dataset_name,
+            datasets_cache_dir=datasets_cache_dir,
         )
 
     def doc_to_text(self, doc):
@@ -724,11 +738,14 @@ class SciQ(ICLMultiChoiceTaskDataset):
 
     metric_type = "acc"
 
-    def __init__(self, tokenizer, dataset_path="sciq", dataset_name=None):
+    def __init__(
+        self, tokenizer, dataset_path="sciq", dataset_name=None, datasets_cache_dir: Optional[str] = None
+    ):
         super().__init__(
             tokenizer=tokenizer,
             dataset_path=dataset_path,
             dataset_name=dataset_name,
+            datasets_cache_dir=datasets_cache_dir,
         )
 
     def doc_to_text(self, doc):
@@ -766,11 +783,14 @@ class ArcEasy(ICLMultiChoiceTaskDataset):
 
     metric_type = "acc"
 
-    def __init__(self, tokenizer, dataset_path="ai2_arc", dataset_name="ARC-Easy"):
+    def __init__(
+        self, tokenizer, dataset_path="ai2_arc", dataset_name="ARC-Easy", datasets_cache_dir: Optional[str] = None
+    ):
         super().__init__(
             tokenizer=tokenizer,
             dataset_path=dataset_path,
             dataset_name=dataset_name,
+            datasets_cache_dir=datasets_cache_dir,
         )
 
     def doc_to_text(self, doc):
@@ -801,11 +821,18 @@ class ArcChallenge(ArcEasy):
 
     metric_type = "len_norm"  # Ideally "pmi_dc"
 
-    def __init__(self, tokenizer, dataset_path="ai2_arc", dataset_name="ARC-Challenge"):
+    def __init__(
+        self,
+        tokenizer,
+        dataset_path="ai2_arc",
+        dataset_name="ARC-Challenge",
+        datasets_cache_dir: Optional[str] = None,
+    ):
         super().__init__(
             tokenizer=tokenizer,
             dataset_path=dataset_path,
             dataset_name=dataset_name,
+            datasets_cache_dir=datasets_cache_dir,
         )
 
 
@@ -836,11 +863,18 @@ class BasicArithmetic(ArcEasy):
 
     metric_type = "acc"
 
-    def __init__(self, tokenizer, dataset_path="allenai/basic_arithmetic", dataset_name=None):
+    def __init__(
+        self,
+        tokenizer,
+        dataset_path="allenai/basic_arithmetic",
+        dataset_name=None,
+        datasets_cache_dir: Optional[str] = None,
+    ):
         super().__init__(
             tokenizer=tokenizer,
             dataset_path=dataset_path,
             dataset_name=dataset_name,
+            datasets_cache_dir=datasets_cache_dir,
         )
 
 
@@ -857,11 +891,18 @@ class CommonsenseQA(ArcEasy):
 
     metric_type = "len_norm"
 
-    def __init__(self, tokenizer, dataset_path="tau/commonsense_qa", dataset_name=None):
+    def __init__(
+        self,
+        tokenizer,
+        dataset_path="tau/commonsense_qa",
+        dataset_name=None,
+        datasets_cache_dir: Optional[str] = None,
+    ):
         super().__init__(
             tokenizer=tokenizer,
             dataset_path=dataset_path,
             dataset_name=dataset_name,
+            datasets_cache_dir=datasets_cache_dir,
         )
 
 
@@ -877,11 +918,14 @@ class SocialIQa(ICLMultiChoiceTaskDataset):
 
     metric_type = "len_norm"
 
-    def __init__(self, tokenizer, dataset_path="social_i_qa", dataset_name=None):
+    def __init__(
+        self, tokenizer, dataset_path="social_i_qa", dataset_name=None, datasets_cache_dir: Optional[str] = None
+    ):
         super().__init__(
             tokenizer=tokenizer,
             dataset_path=dataset_path,
             dataset_name=dataset_name,
+            datasets_cache_dir=datasets_cache_dir,
         )
 
     def doc_to_text(self, doc):
@@ -924,11 +968,14 @@ class COPA(ICLMultiChoiceTaskDataset):
 
     metric_type = "acc"
 
-    def __init__(self, tokenizer, dataset_path="super_glue", dataset_name="copa"):
+    def __init__(
+        self, tokenizer, dataset_path="super_glue", dataset_name="copa", datasets_cache_dir: Optional[str] = None
+    ):
         super().__init__(
             tokenizer=tokenizer,
             dataset_path=dataset_path,
             dataset_name=dataset_name,
+            datasets_cache_dir=datasets_cache_dir,
         )
 
     def doc_to_text(self, doc):
@@ -966,11 +1013,14 @@ class RTE(ICLMultiChoiceTaskDataset):
 
     metric_type = "len_norm"
 
-    def __init__(self, tokenizer, dataset_path="glue", dataset_name="rte"):
+    def __init__(
+        self, tokenizer, dataset_path="glue", dataset_name="rte", datasets_cache_dir: Optional[str] = None
+    ):
         super().__init__(
             tokenizer=tokenizer,
             dataset_path=dataset_path,
             dataset_name=dataset_name,
+            datasets_cache_dir=datasets_cache_dir,
         )
 
     def doc_to_text(self, doc):
@@ -1005,11 +1055,14 @@ class CommitmentBank(ICLMultiChoiceTaskDataset):
 
     metric_type = "acc"
 
-    def __init__(self, tokenizer, dataset_path="super_glue", dataset_name="cb"):
+    def __init__(
+        self, tokenizer, dataset_path="super_glue", dataset_name="cb", datasets_cache_dir: Optional[str] = None
+    ):
         super().__init__(
             tokenizer=tokenizer,
             dataset_path=dataset_path,
             dataset_name=dataset_name,
+            datasets_cache_dir=datasets_cache_dir,
         )
 
     def doc_to_text(self, doc):
@@ -1042,11 +1095,14 @@ class MRPC(ICLMultiChoiceTaskDataset):
 
     metric_type = "f1"
 
-    def __init__(self, tokenizer, dataset_path="glue", dataset_name="mrpc"):
+    def __init__(
+        self, tokenizer, dataset_path="glue", dataset_name="mrpc", datasets_cache_dir: Optional[str] = None
+    ):
         super().__init__(
             tokenizer=tokenizer,
             dataset_path=dataset_path,
             dataset_name=dataset_name,
+            datasets_cache_dir=datasets_cache_dir,
         )
 
     @classmethod
@@ -1107,11 +1163,14 @@ class SST2(ICLMultiChoiceTaskDataset):
 
     metric_type = "acc"
 
-    def __init__(self, tokenizer, dataset_path="glue", dataset_name="sst2"):
+    def __init__(
+        self, tokenizer, dataset_path="glue", dataset_name="sst2", datasets_cache_dir: Optional[str] = None
+    ):
         super().__init__(
             tokenizer=tokenizer,
             dataset_path=dataset_path,
             dataset_name=dataset_name,
+            datasets_cache_dir=datasets_cache_dir,
         )
 
     @classmethod
@@ -1233,6 +1292,7 @@ class MMLU(ICLMultiChoiceTaskDataset):
         split="validation",
         prompt_variations=None,
         mc_labels=False,
+        datasets_cache_dir: Optional[str] = None,
     ):
         dataset_names = []
         # Collect the relevant categories
@@ -1259,15 +1319,15 @@ class MMLU(ICLMultiChoiceTaskDataset):
                 raise ValueError(f"Unknown prompt variations: {prompt_variations}")
             # Need to grab the dev set for the few-shot prompts
             for name in dataset_names:
-                self.dev_set[name] = datasets.load_dataset(
-                    path=dataset_path, name=name, split="dev", trust_remote_code=True
-                )
+                dev_set = load_dataset(dataset_path, name, "dev", datasets_cache_dir)
+                self.dev_set[name] = dev_set
         super().__init__(
             tokenizer=tokenizer,
             dataset_path=dataset_path,
             dataset_name=dataset_names,
             split=split,
             prompts=prompts,
+            datasets_cache_dir=datasets_cache_dir,
         )
 
     def doc_to_text(self, doc):
@@ -1337,11 +1397,18 @@ class TriviaQACELoss(ICLMultiChoiceTaskDataset):
 
     metric_type = "ce_loss"
 
-    def __init__(self, tokenizer, dataset_path="trivia_qa", dataset_name="rc.wikipedia.nocontext"):
+    def __init__(
+        self,
+        tokenizer,
+        dataset_path="trivia_qa",
+        dataset_name="rc.wikipedia.nocontext",
+        datasets_cache_dir: Optional[str] = None,
+    ):
         super().__init__(
             tokenizer=tokenizer,
             dataset_path=dataset_path,
             dataset_name=dataset_name,
+            datasets_cache_dir=datasets_cache_dir,
         )
 
     def doc_to_text(self, doc):
@@ -1369,11 +1436,14 @@ class NaturalQuestionsCELoss(ICLMultiChoiceTaskDataset):
 
     metric_type = "ce_loss"
 
-    def __init__(self, tokenizer, dataset_path="nq_open", dataset_name=None):
+    def __init__(
+        self, tokenizer, dataset_path="nq_open", dataset_name=None, datasets_cache_dir: Optional[str] = None
+    ):
         super().__init__(
             tokenizer=tokenizer,
             dataset_path=dataset_path,
             dataset_name=dataset_name,
+            datasets_cache_dir=datasets_cache_dir,
         )
 
     def doc_to_text(self, doc):

--- a/olmo/eval/downstream.py
+++ b/olmo/eval/downstream.py
@@ -17,7 +17,7 @@ from ..tokenizer import Tokenizer
 log = logging.getLogger(__name__)
 
 
-def load_dataset(path, name, split, datasets_cache_dir: Optional[str] = None):
+def load_dataset(path: str, name: Optional[str], split: str, datasets_cache_dir: Optional[str] = None):
     dataset = None
 
     # First try to load dataset on only FS rank 0, to avoid unnecessary network load.

--- a/olmo/util.py
+++ b/olmo/util.py
@@ -16,6 +16,7 @@ from typing import Any, Callable, Dict, Optional, Tuple, Union
 
 import boto3
 import botocore.exceptions as boto_exceptions
+import datasets
 import rich
 from botocore.config import Config
 from cached_path.schemes import SchemeClient, add_scheme_client
@@ -646,6 +647,22 @@ def _http_get_bytes_range(scheme: str, host_name: str, path: str, bytes_start: i
         len(result) == num_bytes
     ), f"expected {num_bytes} bytes, got {len(result)}"  # Some web servers silently ignore range requests and send everything
     return result
+
+
+def load_dataset_from_disk(hf_path: str, name: Optional[str], split: str, datasets_dir: str):
+    dataset_path = os.path.join(datasets_dir, hf_path, name or "none", split)
+    return datasets.load_from_disk(dataset_path)
+
+
+def save_dataset_to_disk(
+    dataset: datasets.DatasetDict | datasets.Dataset,
+    hf_path: str,
+    name: Optional[str],
+    split: str,
+    datasets_dir: str,
+):
+    dataset_path = os.path.join(datasets_dir, hf_path, name or "none", split)
+    return dataset.save_to_disk(dataset_path)
 
 
 def default_thread_count() -> int:

--- a/olmo/util.py
+++ b/olmo/util.py
@@ -34,7 +34,14 @@ from .exceptions import (
     OLMoNetworkError,
     OLMoThreadError,
 )
-from .torch_util import get_global_rank, get_local_rank, get_node_rank, is_distributed
+from .torch_util import (
+    barrier,
+    get_fs_local_rank,
+    get_global_rank,
+    get_local_rank,
+    get_node_rank,
+    is_distributed,
+)
 
 try:
     from functools import cache
@@ -649,12 +656,12 @@ def _http_get_bytes_range(scheme: str, host_name: str, path: str, bytes_start: i
     return result
 
 
-def load_dataset_from_disk(hf_path: str, name: Optional[str], split: str, datasets_dir: str):
+def _load_hf_dataset_from_disk(hf_path: str, name: Optional[str], split: str, datasets_dir: str):
     dataset_path = os.path.join(datasets_dir, hf_path, name or "none", split)
     return datasets.load_from_disk(dataset_path)
 
 
-def save_dataset_to_disk(
+def _save_hf_dataset_to_disk(
     dataset: datasets.DatasetDict | datasets.Dataset,
     hf_path: str,
     name: Optional[str],
@@ -663,6 +670,53 @@ def save_dataset_to_disk(
 ):
     dataset_path = os.path.join(datasets_dir, hf_path, name or "none", split)
     return dataset.save_to_disk(dataset_path)
+
+
+def load_hf_dataset(path: str, name: Optional[str], split: str, datasets_cache_dir: Optional[str] = None):
+    dataset = None
+
+    # First try to load dataset on only FS rank 0, to avoid unnecessary network load.
+    # This will hopefully cache the dataset for use in other FS ranks.
+    if get_fs_local_rank() == 0:
+        # Try get dataset from disk.
+        if datasets_cache_dir is not None:
+            try:
+                dataset = _load_hf_dataset_from_disk(path, name, split, datasets_cache_dir)
+            except FileNotFoundError:
+                log.info(
+                    "Path %s name %s split %s not present in local dir %s, loading from online",
+                    path,
+                    name,
+                    split,
+                    datasets_cache_dir,
+                )
+
+        # Get dataset from online if not available on disk
+        if dataset is None:
+            dataset = datasets.load_dataset(
+                path=path,
+                name=name,
+                split=split,
+                trust_remote_code=True,
+            )
+            assert isinstance(dataset, (datasets.DatasetDict, datasets.Dataset))
+            if datasets_cache_dir is not None:
+                _save_hf_dataset_to_disk(dataset, path, name, split, datasets_cache_dir)
+    barrier()
+
+    # Dataset is loaded in FS rank 0
+    if dataset is not None:
+        return dataset
+
+    # Load dataset on non-zero FS ranks
+    if datasets_cache_dir is not None:
+        return _load_hf_dataset_from_disk(path, name, split, datasets_cache_dir)
+    return datasets.load_dataset(
+        path=path,
+        name=name,
+        split=split,
+        trust_remote_code=True,
+    )
 
 
 def default_thread_count() -> int:

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -1,3 +1,9 @@
+import json
+from pathlib import Path
+from typing import Any, List
+
+from datasets import Dataset, DatasetDict
+
 from olmo import util
 
 
@@ -12,3 +18,43 @@ def test_dir_is_empty(tmp_path):
     # Should return false if dir contains anything, even hidden files.
     (dir / ".foo").touch()
     assert not util.dir_is_empty(dir)
+
+
+def _create_and_store_test_hf_dataset(data: List[Any], dataset_path: Path):
+    dataset_path.mkdir(parents=True, exist_ok=True)
+    test_file_path = dataset_path / "test.json"
+    with test_file_path.open("w") as f:
+        json.dump(data, f)
+
+
+def test_load_hf_dataset_gets_correct_data(tmp_path: Path):
+    dataset_path = tmp_path / "test_dataset"
+    cache_path = tmp_path / "cache"
+
+    data = [{"foo": i} for i in range(10)]
+    _create_and_store_test_hf_dataset(data, dataset_path)
+
+    dataset = util.load_hf_dataset(str(dataset_path), name=None, split="test", datasets_cache_dir=str(cache_path))
+    assert isinstance(dataset, (Dataset, DatasetDict))
+    for i in range(10):
+        assert dataset[i]["foo"] == i
+
+
+def test_load_hf_dataset_caches_dataset(tmp_path: Path):
+    dataset_path = tmp_path / "test_dataset"
+    cache_path = tmp_path / "cache"
+
+    data = [{"foo": i} for i in range(10)]
+    _create_and_store_test_hf_dataset(data, dataset_path)
+
+    dataset = util.load_hf_dataset(str(dataset_path), name=None, split="test", datasets_cache_dir=str(cache_path))
+    assert isinstance(dataset, (Dataset, DatasetDict))
+    assert dataset[0]["foo"] == 0
+
+    # Overwrite dataset data and check that old data is loaded
+    data = [{"bar": i} for i in range(10)]
+    _create_and_store_test_hf_dataset(data, dataset_path)
+
+    dataset = util.load_hf_dataset(str(dataset_path), name=None, split="test", datasets_cache_dir=str(cache_path))
+    assert isinstance(dataset, (Dataset, DatasetDict))
+    assert dataset[0]["foo"] == 0


### PR DESCRIPTION
Issue: Loading HF datasets for downstream evals has been slowing down the start of our runs because:
1. Every process tries to load each HF dataset at the same time. This both results in a lot of network traffic to one endpoint (potentially resulting in throttling?), and also maybe some contention over HF's dataset cache on disk.
2. Even when a dataset has already been cached locally, trying to load the dataset results in network calls as HF checks for changes to the data.

Fix: This PR tackles these issues by:
1. Utilizing HF's `load_from_disk` and `save_to_disk` dataset methods to save a local copy of the datasets. These datasets are no longer associated with the online versions, and so loading them from disk does not result in network traffic (as far as I can tell).
2. Making only the FS rank 0 process perform network calls for HF dataset loading. Doing this requires coordination between the processes using `barrier()`, but this seems to be less problematic. Note that barriers are invoked each time a dataset needs to be loaded (on the positive side, if all datasets are already in the cache then there are no barrier invocations).

In a 2 GPU interactive session, the performance goes from 10 mins without this new cache to 1 min with this cache ready beforehand. I have populated a copy of the cache already at `/net/weka/reviz/hf_datasets_cache`.

I haven't yet verified that the evaluation correctness is not affected by this change (because no GPUs available), but I don't expect this to negatively impact eval correctness.

Edit: Now the barrier will always be invoked exactly once per dataset