### PR TITLE
Fix restarts in later epochs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed default distributed training strategy from single-GPU to FSDP
 - Fixed behavior of `effective_memmap_dtype` to prevent unrecognized dtypes to be parsed as `uint16`. 
 
+### Fixed
+
+- Fixed restarting a training run in later epochs so that we no longer need to set the flag `--epoch=INT`. 
+
 ## [v0.4.0](https://github.com/allenai/OLMo/releases/tag/v0.4.0) - 2024-07-11
 
 ### Added

--- a/olmo/data/__init__.py
+++ b/olmo/data/__init__.py
@@ -110,7 +110,8 @@ def build_train_dataloader(
         IterableDataset(
             dataset,  # type: ignore
             train_config.global_train_batch_size,
-            seed=seed + (train_config.epoch or 0),
+            seed=seed,
+            epoch=train_config.epoch or 0,
             shuffle=True,
             drop_last=train_config.data.drop_last,
             world_size=world_size,

--- a/olmo/data/iterable_dataset.py
+++ b/olmo/data/iterable_dataset.py
@@ -30,6 +30,7 @@ class IterableDataset(torch.utils.data.IterableDataset[Dict[str, Any]]):
         global_batch_size: int,
         *,
         seed: int = 0,
+        epoch: int = 0,
         start_index: int = 0,
         max_examples: Optional[int] = None,
         shuffle: bool = True,
@@ -42,6 +43,7 @@ class IterableDataset(torch.utils.data.IterableDataset[Dict[str, Any]]):
     ):
         self.dataset = dataset
         self.seed = seed
+        self.epoch = epoch
         self.start_index = start_index
         self.max_examples = max_examples
         self.shuffle = shuffle
@@ -91,7 +93,7 @@ class IterableDataset(torch.utils.data.IterableDataset[Dict[str, Any]]):
         if self.shuffle:
             # Deterministically shuffle based on epoch and seed
             # Torch built-in randomness is not very random, so we use numpy.
-            rng = np.random.Generator(np.random.PCG64(seed=self.seed))
+            rng = np.random.Generator(np.random.PCG64(seed=self.seed + self.epoch))
             rng.shuffle(indices)
 
         if not self.drop_last:
@@ -116,8 +118,8 @@ class IterableDataset(torch.utils.data.IterableDataset[Dict[str, Any]]):
         else:
             return self._build_global_indices()
 
-    def reshuffle(self):
-        self.seed += 1
+    def reshuffle(self, epoch: int):
+        self.epoch = epoch
         if self.work_dir is not None:
             self._build_and_save_global_indices()
 

--- a/olmo/train.py
+++ b/olmo/train.py
@@ -1269,7 +1269,7 @@ class Trainer:
                             python_profiler.print_stats(sort=SortKey.CUMULATIVE)
                             python_profiler = None
                 else:
-                    log.info(f"Epoch {epoch} complete")
+                    log.info("Training epoch complete")
                     self.epoch = epoch + 1
                     self.global_train_examples_seen_this_epoch = 0
                     self.dataset.start_index = 0

--- a/olmo/train.py
+++ b/olmo/train.py
@@ -381,6 +381,7 @@ class Trainer:
         assert self.epoch is not None
         # Reshuffle dataset if needed.
         if self.dataset.epoch != self.epoch:
+            log.info(f"Reshuffling data loader for epoch {self.epoch}...")
             self.dataset.reshuffle(self.epoch)
 
         if self.cfg.fast_forward_batches:
@@ -1268,11 +1269,12 @@ class Trainer:
                             python_profiler.print_stats(sort=SortKey.CUMULATIVE)
                             python_profiler = None
                 else:
-                    log.info("Training epoch complete")
+                    log.info(f"Epoch {epoch} complete")
                     self.epoch = epoch + 1
                     self.global_train_examples_seen_this_epoch = 0
                     self.dataset.start_index = 0
                     if self.epoch < self.max_epochs:
+                        log.info(f"Reshuffling data loader for epoch {self.epoch}...")
                         self.dataset.reshuffle(self.epoch)
                     continue
 

--- a/olmo/train.py
+++ b/olmo/train.py
@@ -317,7 +317,7 @@ class Trainer:
 
     def trainer_state_dict(self) -> Dict[str, Any]:
         return {
-            "epoch": self.epoch,
+            "epoch": self.epoch or 0,
             "global_step": self.global_step,
             "global_train_examples_seen_this_epoch": self.global_train_examples_seen_this_epoch,
             "global_train_tokens_seen": self.global_train_tokens_seen,
@@ -352,7 +352,7 @@ class Trainer:
         ]
 
         # Dataset / dataloader position.
-        checkpoint_epoch = state_dict.get("epoch", 0)
+        checkpoint_epoch = state_dict.get("epoch") or 0
         self.global_step = state_dict["global_step"]
         self.global_train_examples_seen_this_epoch = state_dict.get(
             "global_train_examples_seen_this_epoch",
@@ -377,6 +377,11 @@ class Trainer:
         elif checkpoint_epoch != self.epoch:
             log.info(f"Starting new epoch (epoch = {self.epoch})")
             self.global_train_examples_seen_this_epoch = 0
+
+        assert self.epoch is not None
+        # Reshuffle dataset if needed.
+        if self.dataset.epoch != self.epoch:
+            self.dataset.reshuffle(self.epoch)
 
         if self.cfg.fast_forward_batches:
             log.info(f"Fast-forwarding data loader by {self.cfg.fast_forward_batches:,d} steps")
@@ -1268,7 +1273,7 @@ class Trainer:
                     self.global_train_examples_seen_this_epoch = 0
                     self.dataset.start_index = 0
                     if self.epoch < self.max_epochs:
-                        self.dataset.reshuffle()
+                        self.dataset.reshuffle(self.epoch)
                     continue
 
                 break


### PR DESCRIPTION
This PR fixes restarting a training run in later epochs so that we no longer need to set the flag `--epoch=INT`. 