### PR TITLE
Ensure attn_norm does not affect the residual stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed restarting a training run in later epochs so that we no longer need to set the flag `--epoch=INT`. 
+- Fixed restarting a training run in later epochs so that we no longer need to set the flag `--epoch=INT`.
+- Fix bug where the attention norm, when applied before the attention block, was modifying the residual stream.
 
 ## [v0.4.0](https://github.com/allenai/OLMo/releases/tag/v0.4.0) - 2024-07-11
 

--- a/olmo/model.py
+++ b/olmo/model.py
@@ -734,11 +734,11 @@ class OLMoSequentialBlock(OLMoBlock):
         # apply norm before
         if not self.config.norm_after:
             if self._activation_checkpoint_fn is not None:
-                x = self._activation_checkpoint_fn(self.attn_norm, x)
+                qkv = self._activation_checkpoint_fn(self.attn_norm, x)
             else:
-                x = self.attn_norm(x)
+                qkv = self.attn_norm(x)
 
-        qkv = self.att_proj(x)
+        qkv = self.att_proj(qkv)
 
         if self.config.clip_qkv is not None:
             qkv.clamp_(min=-self.config.clip_qkv, max=self.config.clip_qkv)


### PR DESCRIPTION
Issue: The attention norm, when applied before the attention block, was modifying the residual stream. This was introduced in https://github.com/allenai/OLMo/commit/aac4bdd1b417c379b79fdba225bbbe01cac9e4ef.

Fix: Ensure the attention norm does not modify the residual stream.

Testing: I used a script to check that this PR made the output match that from https://github.com/allenai/OLMo/tree/ladder-1xC, which is healthy according to @AkshitaB. Before the fix, the outputs (and inputs) would start disagreeing at the feed forward norm. 