### PR TITLE
Set `preserve_rng_state` to True if there is dropout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Swapped in correct flan data mix.
 - Fix bug where the attention norm, when applied before the attention block, was modifying the residual stream.
 - Fixed `OLMo.from_checkpoint()` so that it correctly loads `olmo_core` and `torch_new` style checkpoints.
+- Fixed `preserve_rng_state` being incorrectly set to False when doing gradient checkpointing with dropout 
 
 
 ## [v0.4.0](https://github.com/allenai/OLMo/releases/tag/v0.4.0) - 2024-07-11

--- a/olmo/model.py
+++ b/olmo/model.py
@@ -77,7 +77,7 @@ log = logging.getLogger(__name__)
 
 
 def activation_checkpoint_function(cfg: ModelConfig):
-    preserve_rng_state = (
+    preserve_rng_state = not (
         (cfg.attention_dropout == 0.0) and (cfg.embedding_dropout == 0.0) and (cfg.residual_dropout == 0.0)
     )
     from torch.utils.checkpoint import checkpoint


### PR DESCRIPTION
This is consistent with the [documentation](https://pytorch.org/docs/stable/checkpoint.html) which states it should be true when deterministic random behavior is required.