### PR TITLE
Change OLMo April/July global batch size to 1024

### DIFF
--- a/configs/official/OLMo-7B-0424.yaml
+++ b/configs/official/OLMo-7B-0424.yaml
@@ -76,7 +76,7 @@ save_num_unsharded_checkpoints_to_keep: -1
 load_path: null
 
 max_duration: 2ep
-global_train_batch_size: 512
+global_train_batch_size: 1024
 device_train_microbatch_size: 2
 
 precision: amp_bf16

--- a/configs/official/OLMo-7B-0724.yaml
+++ b/configs/official/OLMo-7B-0724.yaml
@@ -76,7 +76,7 @@ save_num_unsharded_checkpoints_to_keep: -1
 load_path: null
 
 max_duration: 2ep
-global_train_batch_size: 512
+global_train_batch_size: 1024
 device_train_microbatch_size: 2
 
 precision: amp_bf16


### PR DESCRIPTION
The global batch size was overriden via the command line and so was incorrect in the config file I uploaded originally.