### PR TITLE
Added ability to try loading the latest checkpoint from save folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Added ability to try loading latest checkpoint from save folder using `--try_load_latest_save`.
+
 ## [v0.5.0](https://github.com/allenai/OLMo/releases/tag/v0.5.0) - 2024-08-26
 
 - Fixed conversion to HuggingFace model for DDP-trained models.

--- a/olmo/config.py
+++ b/olmo/config.py
@@ -1027,6 +1027,14 @@ class TrainConfig(BaseConfig):
     The sharded checkpointer type to use to load the initial checkpoint from ``load_path``.
     """
 
+    try_load_latest_save: bool = False
+    """
+    If set and `load_path` is not set, then training will be resumed from the latest checkpoint
+    in the local save folder, falling back to the latest checkpoint in the remote save folder if none
+    exists. If there are no checkpoints in the local and remote save folders, then the model will be
+    initialized from scratch.
+    """
+
     reset_optimizer_state: bool = False
     """
     When this is set, we restore the model from a checkpoint (if given), but we leave the optimizer uninitialized.

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -41,6 +41,7 @@ from olmo.train import Trainer
 from olmo.util import (
     add_cached_path_clients,
     clean_opt,
+    find_latest_checkpoint,
     log_extra_field,
     prepare_cli_environment,
 )
@@ -239,6 +240,20 @@ def main(cfg: TrainConfig) -> None:
         evaluators=evaluators,
         indices_file=indices_file,
     ) as trainer:
+        if cfg.try_load_latest_save and cfg.load_path is None:
+            if (
+                cfg.save_folder is not None
+                and (checkpoint_dir := find_latest_checkpoint(cfg.save_folder)) is not None
+            ):
+                log.info("Setting load path to local checkpoint %s", checkpoint_dir)
+                cfg.load_path = str(checkpoint_dir)
+            elif (
+                cfg.remote_save_folder is not None
+                and (checkpoint_dir := find_latest_checkpoint(cfg.remote_save_folder)) is not None
+            ):
+                log.info("Setting load path to remote checkpoint %s", checkpoint_dir)
+                cfg.load_path = str(checkpoint_dir)
+
         if not cfg.dry_run and not cfg.no_pre_train_checkpoint and cfg.load_path is None:
             if cfg.distributed_strategy == DistributedStrategy.ddp:
                 checkpoint_type = CheckpointType.unsharded


### PR DESCRIPTION
Issue: Our training runs never finish in 1 run of `train.py`. Currently we don't have a nice way to continue training using the same config; we have to set the `load_path` to the latest checkpoint.

Fix: Add an option that tries loading the latest checkpoint from the local and remote save folders (assuming `load_path` is not set). If there are no checkpoints in either folder, then the model initializes from scratch as usual. If this option (`--try_load_latest_save`) is set to `True` for both the initial and subsequent runs, then the first run will initialize and save an initial checkpoint while subsequent runs will resume from the latest checkpoint. 