### PR TITLE
Fix mmlu bpb bug only scoring answer=A questions

### DIFF
--- a/olmo/eval/downstream.py
+++ b/olmo/eval/downstream.py
@@ -1365,6 +1365,9 @@ class MMLU(ICLMultiChoiceTaskDataset):
             return choices
 
     def doc_to_label(self, doc):
+        if self.metric_type in ["ce_loss", "bpb"]:
+            # Only the correct answer is provided for these metrics
+            return 0
         return doc["answer"]
 
     def doc_to_domain_conditional(self, doc):


### PR DESCRIPTION
Same problem as fixed for oe-eval tasks in https://github.com/allenai/OLMo/pull/712, I forgot there was separate handling for MMLU. 

With the previous code, only questions with gold answer A would be counted in the bpb evaluations, now they should all be counted.