### PR TITLE
Set CUDA device before initializing process group

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -64,8 +64,6 @@ def main(cfg: TrainConfig) -> None:
 
     barrier()
 
-    # Set CUDA device.
-    torch.cuda.set_device(f"cuda:{get_local_rank()}")
     device = torch.device("cuda")
 
     # Fill some configuration options.
@@ -341,6 +339,9 @@ if __name__ == "__main__":
     except RuntimeError as e:
         print(f"failed to set multiprocessing start method: {e}")
     log.info(f"Multiprocessing start method set to '{mp.get_start_method()}'")
+
+    # Set CUDA device.
+    torch.cuda.set_device(f"cuda:{get_local_rank()}")
 
     # Initialize process group.
     dist.init_process_group(backend="nccl", timeout=timedelta(minutes=30))


### PR DESCRIPTION
Issue: For some runs we have observed that GPU 0 has higher memory consumption than other GPUs.

Fix: As proposed by @epwalsh, setting the CUDA device before initializing the process group appears to help. I have not confirmed that GPU memory becomes equal between GPUs (because of wandb issues), but have seen reduced memory consumption in GPU 0. There shouldn't be any harm to making this change, even if it is not 100% confirmed.