### PR TITLE
Add intermediate size to hf_olmo

### DIFF
--- a/hf_olmo/configuration_olmo.py
+++ b/hf_olmo/configuration_olmo.py
@@ -38,6 +38,13 @@ class OLMoConfig(PretrainedConfig):
         return self.d_model
 
     @property
+    def intermediate_size(self):
+        if hasattr(self, "mlp_hidden_size") and self.mlp_hidden_size is not None:
+            return self.mlp_hidden_size // 2
+        else:
+            return (self.mlp_ratio * self.d_model) // 2
+
+    @property
     def effective_n_kv_heads(self) -> int:
         if self.n_kv_heads is None:
             if self.multi_query_attention is True:


### PR DESCRIPTION
`intermediate_size` is a commonly used field in transformers. We should support it in `hf_olmo`. The current vLLM implementation for `hf_olmo` does a try-except to handle the absence of this field.