### PR TITLE
update mean reduction zloss to ignore labels == ignore_index 

### DIFF
--- a/olmo/train.py
+++ b/olmo/train.py
@@ -135,7 +135,8 @@ def cross_entropy_loss(
 
     z_squared = logits.logsumexp(-1).pow(2)
     if reduction == "mean":
-        z_squared = (z_squared * (labels != ignore_index)).mean()
+        mask = labels != ignore_index
+        z_squared = (z_squared * mask).sum() / mask.sum()
     elif reduction == "sum":
         z_squared = (z_squared * (labels != ignore_index)).sum()
 


### PR DESCRIPTION
When reduction == "mean", the current implementation sets the z_squared values to 0 vs. ignoring them. These 0 values impact the number of element in the mean reduction and therefore the final z-loss. 

Perhaps this is intentional, but just in case it's not, I made a quick PR to ignore the values vs. setting them to 0. 