### PR TITLE
enable non-distributed training and MPS support

### DIFF
--- a/olmo/config.py
+++ b/olmo/config.py
@@ -719,6 +719,10 @@ class DistributedStrategy(StrEnum):
     Wrap OLMo in torch.distributed.fsdp.FullyShardedDataParallel to train across ranks.
     """
 
+    single = "single"
+    """
+    Train on a single device, i.e., do not distribute trainig. For development and debugging.
+    """
 
 class DDPGradSyncMode(StrEnum):
     batch = "batch"

--- a/olmo/torch_util.py
+++ b/olmo/torch_util.py
@@ -156,3 +156,11 @@ def get_cumulative_document_lengths(doc_lens: torch.Tensor) -> torch.Tensor:
             torch.cumsum(doc_lens.masked_select(doc_lens != 0), 0, dtype=torch.int32),
         ]
     )
+
+class SingleAccelerator(torch.nn.Module):
+    process_group = None
+    def __init__(self, module: torch.nn.Module):
+        super().__init__()
+        self.module = module
+    def forward(self, *args, **kwargs):
+        return self.module(*args, **kwargs)

--- a/olmo/train.py
+++ b/olmo/train.py
@@ -332,7 +332,8 @@ class Trainer:
                 "python": random.getstate(),
                 "numpy": np.random.get_state(),
                 "torch": torch.random.get_rng_state(),
-                "cuda": torch.cuda.get_rng_state(),
+                "cuda": torch.cuda.get_rng_state() if torch.cuda.is_available() else None,
+                "mps": torch.mps.get_rng_state() if torch.mps.is_available() else None,
             },
         }
 
@@ -430,7 +431,10 @@ class Trainer:
         random.setstate(rng_state["python"])
         np.random.set_state(rng_state["numpy"])
         torch.set_rng_state(rng_state["torch"])
-        torch.cuda.set_rng_state(rng_state["cuda"])
+        if rng_state["cuda"] is not None:
+            torch.cuda.set_rng_state(rng_state["cuda"])
+        if rng_state["mps"] is not None:
+            torch.mps.set_rng_state(rng_state["mps"])
 
     def _save_checkpoint(
         self, checkpointer: Checkpointer, checkpoint_type: CheckpointType

--- a/olmo/train.py
+++ b/olmo/train.py
@@ -431,9 +431,9 @@ class Trainer:
         random.setstate(rng_state["python"])
         np.random.set_state(rng_state["numpy"])
         torch.set_rng_state(rng_state["torch"])
-        if rng_state["cuda"] is not None:
+        if rng_state.get("cuda", None) is not None:
             torch.cuda.set_rng_state(rng_state["cuda"])
-        if rng_state["mps"] is not None:
+        if rng_state.get("mps", None) is not None:
             torch.mps.set_rng_state(rng_state["mps"])
 
     def _save_checkpoint(

--- a/olmo/train.py
+++ b/olmo/train.py
@@ -1251,7 +1251,7 @@ class Trainer:
                             stop_at = min(stop_at, self.global_step + extra_steps)
 
                     # Maybe save sharded checkpoint.
-                    if self.cfg.distributed_strategy != DistributedStrategy.ddp:
+                    if self.cfg.distributed_strategy == DistributedStrategy.fsdp:
                         if save_checkpoints and (
                             cancel_initiated
                             or (

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -219,7 +219,7 @@ def main(cfg: TrainConfig) -> None:
         )
     elif cfg.distributed_strategy == DistributedStrategy.single:
         param_init_fn = None
-        dist_model = SINGLE(olmo_model)
+        dist_model = SINGLE(olmo_model.to(device))
 
     # when param_init_fn is None, FSDP will call reset_parameters() automatically
     if param_init_fn is not None or cfg.distributed_strategy == DistributedStrategy.ddp:

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -294,7 +294,7 @@ def main(cfg: TrainConfig) -> None:
                 cfg.reset_optimizer_state = False
 
         if not cfg.dry_run and not cfg.no_pre_train_checkpoint and cfg.load_path is None:
-            if cfg.distributed_strategy == DistributedStrategy.ddp:
+            if cfg.distributed_strategy in [DistributedStrategy.ddp, DistributedStrategy.single]:
                 checkpoint_type = CheckpointType.unsharded
 
                 if cfg.save_interval_unsharded is None:
@@ -312,21 +312,8 @@ def main(cfg: TrainConfig) -> None:
                 checkpoint_type = (
                     CheckpointType.sharded if cfg.save_num_checkpoints_to_keep != 0 else CheckpointType.unsharded
                 )
-            elif cfg.distributed_strategy == DistributedStrategy.single:
-                #raise NotImplementedError(f"Distributed strategy {cfg.distributed_strategy} not supported yet!")
-                checkpoint_type = CheckpointType.unsharded
-
-                if cfg.save_interval_unsharded is None:
-                    log.warning(
-                        "single accelerator training requires setting `save_interval_unsharded`. Using the value set for `save_interval`."
-                    )
-                    cfg.save_interval_unsharded = cfg.save_interval
-
-                if cfg.save_num_unsharded_checkpoints_to_keep == 0:
-                    log.warning(
-                        "single accelerator training requires setting `save_num_unsharded_checkpoints_to_keep`. Using the value set for `save_num_checkpoints_to_keep`."
-                    )
-                    cfg.save_num_unsharded_checkpoints_to_keep = cfg.save_num_checkpoints_to_keep
+            else:
+                raise NotImplementedError(f"Distributed strategy {cfg.distributed_strategy} not supported yet!")
 
             # We save a checkpoint up-front to make sure this won't fail (due to disk space or whatever).
             log.info("Saving pre-train checkpoint...")


### PR DESCRIPTION
Current OLMo is locked to DDP or FSDP distributed training on CUDA accelerators.

This PR does two things:
1) It adds a single accelerator mode (distributed_strategy: single) through a simple wrapper module.
2) It adds support for MPS, allowing development and debugging on ARM64 Mac machines.

The primary motivation is to make and test code changes without having to block GPU resources. In addition, tiny models can actually be trained on a sufficiently equipped system.