### PR TITLE
update GPU check clusters to ai2/neptune-cirrascale

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -147,8 +147,7 @@ jobs:
                   gpuCount: 1
                 constraints:
                   cluster:
-                    - ai2/general-cirrascale
-                    - ai2/allennlp-cirrascale
+                    - ai2/neptune-cirrascale
                 envVars:
                   - name: COMMIT_SHA
                     value: ${{ env.COMMIT_SHA }}


### PR DESCRIPTION
I noticed the GPU check is failing because it's still looking for old cluster names; this updates it