### PR TITLE
Fix device detection logic in train.py

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -424,12 +424,12 @@ if __name__ == "__main__":
         raise OLMoCliError(f"Usage: {sys.argv[0]} [CONFIG_PATH] [OPTIONS]")
 
     cfg = TrainConfig.load(yaml_path, [clean_opt(s) for s in args_list])
-    if torch.device("mps"):
+    if torch.backends.mps.is_available():
         log.info("Device is MPS. Updating config...")
         cfg.model.init_device = "mps"
         cfg.distributed_strategy = "single"  # type: ignore
 
-    if torch.device("cpu"):
+    if not torch.cuda.is_available() and not torch.backends.mps.is_available():
         log.info("Device is CPU. Updating config...")
         cfg.model.init_device = "cpu"
         cfg.distributed_strategy = "single"  # type: ignore


### PR DESCRIPTION
This PR fixes a bug in the device detection logic in train.py.

## Issue
The code incorrectly used `torch.device()` to check for device availability, which always evaluates to `True` in a boolean context. This caused both MPS and CPU conditions to always be true, resulting in the configuration always ending with `cfg.model.init_device = "cpu"` and `cfg.distributed_strategy = "single"`.

## Fix
Changed to use proper availability checks with `torch.backends.mps.is_available()` and `torch.cuda.is_available()`.

## Note
Despite this bug, training has worked because the actual device allocation happens correctly in the `main()` function

The fix ensures correct configuration from the start, avoiding initialization in-efficiency.