### PR TITLE
Fix tokenizer.encode() to respect add_special_tokens=False parameter

### DIFF
--- a/olmo/tokenizer.py
+++ b/olmo/tokenizer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import inspect
 from pathlib import Path
 from typing import List, Optional, Union
 
@@ -180,7 +181,12 @@ class Tokenizer:
         if truncate_to is not None and add_special_tokens:
             truncate_to -= self.num_special_tokens_to_add(False)
 
-        batch_encoding = self.base_tokenizer.encode_batch(inputs)
+        # Check if the base tokenizer's encode_batch method supports add_special_tokens parameter
+        if 'add_special_tokens' in inspect.signature(self.base_tokenizer.encode_batch).parameters:
+            batch_encoding = self.base_tokenizer.encode_batch(inputs, add_special_tokens=False)
+        else:
+            # Fallback to original behavior if the parameter isn't supported
+            batch_encoding = self.base_tokenizer.encode_batch(inputs)
 
         all_input_ids = []
         for encoding in batch_encoding:


### PR DESCRIPTION
## Problem
The `add_special_tokens=False` parameter in the tokenizer's `encode`/`encode_batch` methods doesn't work as expected. Even when set to `False`, special tokens (like EOS) are still being added to the encoded output.

## Root Cause
The issue occurs because the `add_special_tokens` parameter is not being passed to the base tokenizer's `encode_batch` method. While our code correctly handles the parameter after encoding, by that point the base tokenizer may have already added special tokens.

## Solution
This PR adds a check to see if the base tokenizer's `encode_batch` method supports the `add_special_tokens` parameter, and if so, passes it to ensure special tokens are not added by the base tokenizer. This provides backward compatibility with tokenizers that don't support this parameter.

Fixes #765