### PR TITLE
Downgraded ai2-olmo-core version

### DIFF
--- a/.github/actions/setup-venv/action.yml
+++ b/.github/actions/setup-venv/action.yml
@@ -30,7 +30,7 @@ runs:
         # Get the exact Python version to use in the cache key.
         echo "PYTHON_VERSION=$(python --version)" >> $GITHUB_ENV
 
-    - uses: actions/cache@v2
+    - uses: actions/cache@v4
       id: virtualenv-cache
       with:
         path: .venv

--- a/.github/actions/setup-venv/action.yml
+++ b/.github/actions/setup-venv/action.yml
@@ -30,7 +30,7 @@ runs:
         # Get the exact Python version to use in the cache key.
         echo "PYTHON_VERSION=$(python --version)" >> $GITHUB_ENV
 
-    - uses: actions/cache@v4
+    - uses: actions/cache@v2
       id: virtualenv-cache
       with:
         path: .venv

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.10']
+        python: ['3.8', '3.10']
         task:
           - name: Lint
             run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ description = "Open Language Model (OLMo)"
 authors = [
     { name = "Allen Institute for Artificial Intelligence", email = "olmo@allenai.org" }
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.8"
 license = { file = "LICENSE" }
 dependencies = [
     "numpy<2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ license = { file = "LICENSE" }
 dependencies = [
     "numpy<2",
     "torch>=2.1",
-    "ai2-olmo-core>=1.8.0",
+    "ai2-olmo-core==0.1.0",
     "omegaconf",
     "rich",
     "boto3",

--- a/test_fixtures/test-olmo-model/config.json
+++ b/test_fixtures/test-olmo-model/config.json
@@ -44,7 +44,7 @@
   "rope_theta": 10000,
   "scale_emb_init": false,
   "scale_logits": false,
-  "transformers_version": "4.52.0.dev0",
+  "transformers_version": "4.48.2",
   "use_cache": true,
   "vocab_size": 50257,
   "weight_tying": true


### PR DESCRIPTION
Downgraded the ai2-olmo-core version from 1.8.0 to 0.1.0 because the trainer was failing to load the sharded checkpoints, and we were encountering difficulties while unsharding the checkpoints. 