### PR TITLE
Update README.md for dependencies installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ For training and fine-tuning, we recommend installing from source:
 ```bash
 git clone https://github.com/allenai/OLMo.git
 cd OLMo
-pip install -e .[all]
+pip install -e ".[all]"
 ```
 You can also install from PyPI with:
 ```bash


### PR DESCRIPTION
Add quote around .[all], otherwise it would throw error as `no matches found .[all]`