### PR TITLE
Improve run_dataloader.py usability and performance feedback(addresses #869)

### DIFF
--- a/scripts/run_dataloader.py
+++ b/scripts/run_dataloader.py
@@ -1,6 +1,7 @@
 import logging
+import time
 from pathlib import Path
-from typing import Dict
+from typing import Dict, Optional
 
 import numpy as np
 import torch.distributed as dist
@@ -18,7 +19,7 @@ from olmo.util import clean_opt, prepare_cli_environment
 log = logging.getLogger("run_dataloader")
 
 
-def main(cfg: TrainConfig, output_dir: Path) -> None:
+def main(cfg: TrainConfig, output_dir: Path, max_batches: Optional[int] = None) -> None:
     # Set seed
     seed_all(cfg.seed)
 
@@ -57,12 +58,23 @@ def main(cfg: TrainConfig, output_dir: Path) -> None:
     batches_read = 0
     name_to_batches: Dict[str, np.array] = {}
 
-    for batch_number, batch in enumerate(tqdm(train_loader)):
+    # Track throughput statistics
+    start_time = time.time()
+    total_bytes = 0
+
+    progress_bar = tqdm(train_loader, total=max_batches, desc="Processing batches")
+    for batch_number, batch in enumerate(progress_bar):
+        # Check if we've reached the maximum number of batches
+        if max_batches is not None and batch_number >= max_batches:
+            log.info(f"Reached max_batches limit ({max_batches}), stopping.")
+            break
+
         for name, source_t in batch.items():
             source_t = source_t.numpy()
             if name == "input_ids":
                 assert source_t.max() <= 2**16
                 source_t = source_t.astype(np.uint16)
+                total_bytes += source_t.nbytes
             try:
                 target_t = name_to_batches[name]
             except KeyError:
@@ -70,6 +82,13 @@ def main(cfg: TrainConfig, output_dir: Path) -> None:
                 name_to_batches[name] = target_t
             target_t[batches_read] = source_t
         batches_read += 1
+
+        # Update progress bar with throughput stats
+        elapsed = time.time() - start_time
+        if elapsed > 0:
+            batches_per_sec = (batch_number + 1) / elapsed
+            mb_per_sec = (total_bytes / (1024 * 1024)) / elapsed
+            progress_bar.set_postfix({"batches/s": f"{batches_per_sec:.2f}", "MB/s": f"{mb_per_sec:.2f}"})
 
         if batches_read >= batches_per_file:
             file_start = batch_number - batches_per_file + 1
@@ -79,12 +98,42 @@ def main(cfg: TrainConfig, output_dir: Path) -> None:
                 np.save(filename, t[:batches_read])
             batches_read = 0
 
+    # Save any remaining batches
+    if batches_read > 0:
+        file_start = batch_number - batches_read + 1
+        file_end = batch_number + 1
+        for name, t in name_to_batches.items():
+            filename = output_dir / f"{name}-{file_start:07}-{file_end:07}.npy"
+            np.save(filename, t[:batches_read])
+        log.info(f"Saved final {batches_read} batches.")
+
+    # Print final statistics
+    elapsed = time.time() - start_time
+    log.info(
+        f"Processed {batch_number + 1} batches in {elapsed:.1f}s ({(batch_number + 1) / elapsed:.2f} batches/s)"
+    )
+    log.info(
+        f"Total data read: {total_bytes / (1024 * 1024):.2f} MB ({total_bytes / (1024 * 1024) / elapsed:.2f} MB/s)"
+    )
+
 
 if __name__ == "__main__":
     import argparse
 
     parser = argparse.ArgumentParser(description="replay the dataloader and write batches out to files")
     parser.add_argument("-o", type=str, help="output directory")
+    parser.add_argument(
+        "--max_batches",
+        type=int,
+        default=None,
+        help="Maximum number of batches to process (useful for testing or partial runs)",
+    )
+    parser.add_argument(
+        "--local_data_root",
+        type=str,
+        default=None,
+        help="Local directory root to substitute for remote paths (e.g., /mnt/tank/ replaces s3://)",
+    )
     parser.add_argument("config_file", type=str, help="config file")
     args, other_args = parser.parse_known_args()
     output_dir = Path(args.o)
@@ -106,9 +155,30 @@ if __name__ == "__main__":
 
     cfg = TrainConfig.load(args.config_file, args_list)
 
-    # If you have the data downloaded locally, uncomment this and fix the path for a massive speedup.
-    # cfg.data.paths = [
-    #    p.replace("s3://", "/mnt/tank/") for p in cfg.data.paths
-    # ]
+    # Substitute remote paths with local paths if --local_data_root is provided
+    if args.local_data_root:
+        if cfg.data.paths:
+            original_paths = cfg.data.paths
+            cfg.data.paths = []
+            for p in original_paths:
+                for scheme in ("s3://", "r2://", "weka://", "gs://"):
+                    if p.startswith(scheme):
+                        # Extract bucket and key, then join with local root
+                        local_path = args.local_data_root.rstrip("/") + "/" + p.split("://", 1)[1]
+                        log.info(f"Substituting remote path: {p} -> {local_path}")
+                        p = local_path
+                        break
+                cfg.data.paths.append(p)
+    else:
+        # Warn user about potential slow remote access
+        if cfg.data.paths:
+            remote_paths = [
+                p for p in cfg.data.paths if any(p.startswith(s) for s in ("s3://", "r2://", "weka://", "gs://"))
+            ]
+            if remote_paths:
+                log.warning(
+                    f"Loading data from {len(remote_paths)} remote path(s). This may be very slow. "
+                    "Consider using --local_data_root to use locally cached data for faster processing."
+                )
 
-    main(cfg, output_dir)
+    main(cfg, output_dir, max_batches=args.max_batches)


### PR DESCRIPTION
## Summary

Improves `run_dataloader.py` usability for users who need to extract partial training data or debug data loading performance (addresses #869).

## Changes

- Add `--max_batches` flag to limit processing (useful for testing or partial data extraction)
- Add `--local_data_root` flag to auto-substitute remote paths with local cached data
- Add real-time throughput statistics (batches/s, MB/s) to progress bar
- Warn users when loading from remote paths without local cache
- Fix: Save any remaining batches that don't fill a complete file (was silently dropping data)
- Log final statistics at completion

## Motivation

Users running `run_dataloader.py` with remote data (S3/R2) experience very slow performance due to per-chunk network requests (#869 reported only 44 batches after running overnight).

This PR makes the script more user-friendly by:
1. Allowing partial runs with `--max_batches` for testing
2. Making it easier to use local data with `--local_data_root`  
3. Providing clear feedback about processing speed

## Example usage

```bash
# Process only first 100 batches
python scripts/run_dataloader.py -o ./output --max_batches 100 config.yaml

# Use locally cached data instead of S3
python scripts/run_dataloader.py -o ./output --local_data_root /mnt/data config.yaml