### PR TITLE
docs: add community health files and README updates

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,32 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We pledge to make participation in our community a harassment-free experience
+for everyone, regardless of age, body size, disability, ethnicity, gender identity,
+level of experience, nationality, personal appearance, race, religion, or sexual identity.
+
+## Our Standards
+
+**Positive behavior includes:**
+- Demonstrating empathy and kindness
+- Respecting differing opinions and experiences
+- Giving and gracefully accepting constructive feedback
+- Focusing on what is best for the community
+
+**Unacceptable behavior includes:**
+- Harassment, trolling, or personal attacks
+- Publishing others' private information without permission
+- Sexualized language or unwelcome advances
+
+## Enforcement
+
+Instances of unacceptable behavior may be reported to community leaders.
+All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+Adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1.
+
+---
+*[Mukller](https://github.com/Mukller)*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,29 @@
+# Contributing
+
+Thank you for your interest in contributing! We welcome contributions of all kinds.
+
+## How to Contribute
+
+### Reporting Bugs
+- Check existing [issues](../../issues) to avoid duplicates
+- Open a new issue with a clear title, description, and steps to reproduce
+
+### Suggesting Features
+- Open an issue with the `enhancement` label
+
+### Submitting Code
+
+1. **Fork** this repository
+2. **Create a branch**: `git checkout -b feature/your-feature`
+3. **Make your changes** and commit: `git commit -m "feat: description"`
+4. **Push** and open a **Pull Request**
+
+## Guidelines
+
+- Follow existing code style and conventions
+- Keep PRs focused on a single concern
+- Update documentation when changing behavior
+- Be respectful — see [Code of Conduct](CODE_OF_CONDUCT.md)
+
+---
+*[Mukller](https://github.com/Mukller)*

--- a/README.md
+++ b/README.md
@@ -246,3 +246,15 @@ where `body.json` is of the form:
       url={https://arxiv.org/abs/2501.00656}, 
 }
 ```
+
+
+## Contributing
+
+We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on
+how to report bugs, suggest features, and submit pull requests.
+
+By participating, you agree to our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+---
+
+*[Mukller](https://github.com/Mukller)*


### PR DESCRIPTION
## Add Community Health Files

This PR adds the following to `OLMo`:

- `CONTRIBUTING.md`
- `CODE_OF_CONDUCT.md`
- `README.md`

**CONTRIBUTING.md** — guidelines for bug reports, feature requests, and pull requests.
**CODE_OF_CONDUCT.md** — Contributor Covenant 2.1 standard.
**CHANGELOG.md** — Keep a Changelog format template.
**README.md** — added Contributing section with link to community files.
